### PR TITLE
Add AI workflow documentation for branching and PR reviews

### DIFF
--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -1,0 +1,48 @@
+# AI Collaboration Workflow
+
+## Branch Strategy
+
+- `main` is a protected branch and must remain deployable at all times.
+- Direct pushes to `main` are not allowed.
+- Every change starts from a dedicated feature branch created from the latest `main` (for example, `docs/ai-workflow`, `feature/<topic>`, or `fix/<topic>`).
+- Keep branches focused on a single change set to simplify review and rollback.
+
+## Pull Request Review Workflow
+
+1. Create a branch from `main` and implement only the scoped change.
+2. Run local checks relevant to the change (linting, docs validation, or tests when applicable).
+3. Open a pull request (PR) into `main` with:
+   - A clear title
+   - A concise summary of what changed
+   - Any validation steps reviewers can reproduce
+4. Request at least one reviewer.
+5. Address review feedback in follow-up commits on the same branch.
+6. Merge only after approval and passing required checks.
+7. Prefer squash merge to keep `main` history clean unless repository policy states otherwise.
+
+## Roles of ChatGPT, Codex, and Claude
+
+### ChatGPT
+
+- Acts as a planning and communication assistant.
+- Helps define requirements, acceptance criteria, and user-facing language.
+- Supports drafting documentation, release notes, and review summaries.
+
+### Codex
+
+- Acts as an implementation assistant inside the repository.
+- Makes scoped code or documentation edits, runs checks, and prepares commits.
+- Helps automate repetitive engineering tasks and keeps changes aligned to requested constraints.
+
+### Claude
+
+- Acts as an analytical reviewer and reasoning partner.
+- Provides alternative approaches, edge-case analysis, and critical feedback on proposals.
+- Supports PR quality by stress-testing assumptions and clarifying trade-offs.
+
+## Recommended Collaboration Pattern
+
+- Use ChatGPT to refine scope and acceptance criteria.
+- Use Codex to implement the approved change in a feature branch.
+- Use Claude (or another reviewer) to challenge assumptions and review quality before merge.
+- Finalize through the standard PR review and approval process.


### PR DESCRIPTION
### Motivation
- Provide a concise, repository-level guide covering branch strategy (no direct pushes to `main`), PR review workflow, and the roles of ChatGPT, Codex, and Claude to standardize AI-assisted collaboration.

### Description
- Add `docs/ai-workflow.md` on branch `docs/ai-workflow` that documents the branch strategy (no direct pushes to `main`), PR review steps, role definitions for `ChatGPT`, `Codex`, and `Claude`, and a recommended collaboration pattern; this is documentation-only and makes no application code changes.

### Testing
- No automated tests were run for this documentation-only change; repository CI and checks will run when the PR is opened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5290618083319194a6d8248a3014)