### PR TITLE
feat: add SIGNAL_PROVIDER abstraction (mock | file) — v0.4.0

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,9 +5,17 @@ from dataclasses import dataclass, field
 @dataclass
 class Settings:
     app_name:     str = "AlphaForgeAI"
-    app_version:  str = "0.3.1"
+    app_version:  str = "0.4.0"
     environment:  str = field(default_factory=lambda: os.getenv("ENVIRONMENT", "development"))
     signal_source: str = field(default_factory=lambda: os.getenv("SIGNAL_SOURCE", "local_snapshot"))
+
+    # ── Signal provider ──────────────────────────────────────────────────────
+    # High-level provider selection.  "mock" serves hardcoded signals directly
+    # (no file I/O).  "file" reads from signal_file_path.  The legacy
+    # signal_source values (local_snapshot / sentinel_ssh) are used when
+    # signal_provider is not set to mock or file.
+    signal_provider:  str = field(default_factory=lambda: os.getenv("SIGNAL_PROVIDER", "mock"))
+    signal_file_path: str = field(default_factory=lambda: os.getenv("SIGNAL_FILE_PATH", ""))
 
     # ── Sentinel SSH connection ──────────────────────────────────────────────
     # Required when signal_source == "sentinel_ssh".

--- a/app/repositories/signal_repository.py
+++ b/app/repositories/signal_repository.py
@@ -121,6 +121,15 @@ def _load_local_snapshot_raw() -> "dict | list":
         return json.load(fh)
 
 
+def _load_file_raw() -> "dict | list":
+    """Read the file at settings.signal_file_path and return the raw parsed JSON."""
+    path = settings.signal_file_path
+    if not path:
+        raise ValueError("SIGNAL_FILE_PATH is not configured")
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
 def _load_sentinel_snapshot_raw() -> "dict | list":
     """
     SSH to Sentinel, run the snapshot script, and return the parsed JSON.
@@ -231,6 +240,58 @@ def _parse_snapshot(raw: "dict | list", source_label: str) -> SignalSnapshot:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+def get_signals_from_file() -> SignalSnapshot:
+    """
+    Load and validate signals from the file at SIGNAL_FILE_PATH.
+
+    Returns a SignalSnapshot on all paths — never raises.
+    """
+    source_label = "file"
+    try:
+        raw = _load_file_raw()
+
+    except FileNotFoundError:
+        log.warning(
+            "[signal_repository] file: file not found at %s",
+            settings.signal_file_path,
+        )
+        return _error_snapshot(
+            source_label,
+            f"Signal file not found: {settings.signal_file_path or '(path not set)'}",
+        )
+
+    except ValueError as exc:
+        log.warning("[signal_repository] file: config error — %s", exc)
+        return _error_snapshot(source_label, f"Config error: {exc}")
+
+    except json.JSONDecodeError as exc:
+        log.warning("[signal_repository] file: invalid JSON — %s", exc)
+        return _error_snapshot(source_label, "Invalid JSON in signal file")
+
+    except OSError as exc:
+        log.warning("[signal_repository] file: I/O error — %s", exc)
+        return _error_snapshot(source_label, f"I/O error: {exc}")
+
+    try:
+        snapshot = _parse_snapshot(raw, source_label)
+    except ValueError as exc:
+        log.warning("[signal_repository] file: malformed payload — %s", exc)
+        return _error_snapshot(source_label, f"Malformed snapshot: {exc}")
+
+    if not snapshot.signals:
+        log.info("[signal_repository] file: loaded but contains no valid signals")
+        from dataclasses import replace
+        return replace(snapshot, status="empty")
+
+    log.info(
+        "[signal_repository] file: loaded %d signal(s) (model=%s generated=%s)",
+        len(snapshot.signals),
+        snapshot.model_version or "unknown",
+        snapshot.generated_at or "unknown",
+    )
+    return snapshot
+
 
 def get_signals() -> SignalSnapshot:
     """

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -34,7 +34,9 @@ async def health():
         "version":     settings.app_version,
         "environment": settings.environment,
         "signals": {
+            "provider":            settings.signal_provider,
             "source":              settings.signal_source,
+            "file_path_set":       bool(settings.signal_file_path),
             "allow_mock_fallback": settings.allow_mock_fallback,
             "sentinel_configured": settings.sentinel_configured,
         },
@@ -63,6 +65,8 @@ async def health_signals():
         })
 
     return {
+        "provider":            settings.signal_provider,
+        "file_path_set":       bool(settings.signal_file_path),
         "source":              settings.signal_source,
         "allow_mock_fallback": settings.allow_mock_fallback,
         "sentinel":            sentinel_info,

--- a/app/services/signal_service.py
+++ b/app/services/signal_service.py
@@ -29,23 +29,49 @@ from dataclasses import replace
 from app.core.config import settings
 from app.domain.signals import Direction, Signal, Timeframe
 from app.repositories.signal_repository import SignalSnapshot
-from app.repositories.signal_repository import get_signals as _repo_get_signals
+from app.repositories.signal_repository import (
+    get_signals as _repo_get_signals,
+    get_signals_from_file as _repo_get_signals_from_file,
+)
 
 log = logging.getLogger(__name__)
 
 
 def get_signals() -> SignalSnapshot:
     """
-    Return a SignalSnapshot from the configured repository.
+    Return a SignalSnapshot from the configured provider.
 
-    If the repository returns no signals and ``settings.allow_mock_fallback``
-    is True, the snapshot is replaced with hardcoded mock signals and
-    ``used_mock_fallback`` is set to True so the template can show a notice.
+    Provider selection (SIGNAL_PROVIDER env var):
+      "mock" — hardcoded mock signals served directly as the primary source.
+      "file" — signals loaded from SIGNAL_FILE_PATH; falls back to mocks if
+               the file is missing/invalid and allow_mock_fallback is True.
+      other  — legacy SIGNAL_SOURCE path (local_snapshot / sentinel_ssh).
 
-    If fallback is disabled (production default), an empty snapshot is
-    returned as-is — the page renders with zero signal cards.
+    If any provider returns no signals and ``settings.allow_mock_fallback``
+    is True the response is replaced with hardcoded mocks.
     """
-    snapshot = _repo_get_signals()
+    provider = settings.signal_provider
+
+    # ── Mock provider: serve mocks directly (no file I/O) ───────────────────
+    if provider == "mock":
+        log.info(
+            "signal_provider=mock — serving mock signals as primary source "
+            "(environment=%s)",
+            settings.environment,
+        )
+        return SignalSnapshot(
+            signals=get_mock_signals(),
+            source="mock",
+            used_mock_fallback=False,
+            status="ok",
+        )
+
+    # ── File provider: load from SIGNAL_FILE_PATH ────────────────────────────
+    if provider == "file":
+        snapshot = _repo_get_signals_from_file()
+    else:
+        # Legacy: local_snapshot / sentinel_ssh via SIGNAL_SOURCE
+        snapshot = _repo_get_signals()
 
     if not snapshot.signals:
         if settings.allow_mock_fallback:


### PR DESCRIPTION
Introduces a SIGNAL_PROVIDER env var that selects how signals reach the UI:
- mock  (default): hardcoded signals served as the primary source, no I/O
- file: signals loaded from SIGNAL_FILE_PATH (same v2 JSON envelope) Falls back to mocks when the file is missing/invalid and allow_mock_fallback is True.
- any other value falls through to the existing SIGNAL_SOURCE path (local_snapshot / sentinel_ssh) so nothing breaks for current deploys.

New SIGNAL_FILE_PATH env var accepted by both config and the file loader. /health and /health/signals now report the active provider and whether a file path is configured.