### PR TITLE
feat: signal generation pipeline — synthetic model v1

### DIFF
--- a/data/signals_snapshot.json
+++ b/data/signals_snapshot.json
@@ -1,99 +1,278 @@
 {
-  "generated_at": "2026-04-22T12:00:00Z",
-  "model_version": "xgboost-nightly",
-  "source": "local_snapshot",
+  "generated_at": "2026-04-26T20:02:52Z",
+  "model_version": "synthetic-v1",
+  "source": "generated",
   "signals": [
     {
-      "symbol": "ETH",
+      "symbol": "AAVE",
       "direction": "LONG",
-      "timeframe": "15m",
-      "confidence": 0.74,
-      "regime": "uptrend",
-      "thesis": "RSI 14 recovered above 48 after a clean pullback to the 20-EMA. Open interest expanding while funding rate stays neutral. L/S ratio at 1.42 — spot buyers absorbing futures pressure.",
+      "timeframe": "4h",
+      "confidence": 0.71,
+      "regime": "accumulation",
+      "thesis": "Broke above 4h resistance with volume confirmation on the 4h. Exchange netflow negative \u2014 withdrawals outpacing deposits, consistent with accumulation rather than distribution.",
       "top_features": [
-        ["rsi_14", 0.18],
-        ["oi_change_1h", 0.15],
-        ["ls_ratio", 0.13],
-        ["ema_20_dist", 0.11]
+        [
+          "volume_ratio",
+          0.27
+        ],
+        [
+          "bb_lower_bounce",
+          0.24
+        ],
+        [
+          "ema_20_dist",
+          0.23
+        ]
       ]
     },
     {
-      "symbol": "SOL",
-      "direction": "LONG",
-      "timeframe": "1h",
-      "confidence": 0.68,
-      "regime": "uptrend",
-      "thesis": "Higher-lows structure intact on the 1h. MACD crossed bullish above signal line. Funding rate neutral — no crowded longs to unwind. Top-trader L/S at 1.28, slightly elevated but not extreme.",
-      "top_features": [
-        ["macd_hist", 0.21],
-        ["higher_lows_count", 0.16],
-        ["funding_rate", 0.12],
-        ["top_trader_ls", 0.10]
-      ]
-    },
-    {
-      "symbol": "INJ",
-      "direction": "LONG",
+      "symbol": "ARB",
+      "direction": "FLAT",
       "timeframe": "15m",
-      "confidence": 0.77,
-      "regime": "uptrend",
-      "thesis": "Three consecutive 15m closes above the 20-EMA with increasing volume. Top-trader long/short flipped bullish in the last 2h. RSI at 59 — momentum present, not yet overbought.",
+      "confidence": 0.43,
+      "regime": "consolidation",
+      "thesis": "ADX below 20 \u2014 trend strength insufficient. Chop index elevated: mean-reverting environment. Waiting for regime clarification before committing direction.",
       "top_features": [
-        ["consec_closes_above_ema", 0.22],
-        ["top_trader_ls", 0.19],
-        ["rsi_14", 0.14],
-        ["volume_ratio", 0.11]
+        [
+          "atr_14",
+          0.19
+        ],
+        [
+          "chop_index",
+          0.19
+        ],
+        [
+          "adx_14",
+          0.15
+        ],
+        [
+          "volatility_ratio",
+          0.06
+        ]
       ]
     },
     {
       "symbol": "AVAX",
       "direction": "LONG",
-      "timeframe": "15m",
-      "confidence": 0.71,
-      "regime": "uptrend",
-      "thesis": "Broke above 4h resistance with volume confirmation on the 15m. Exchange netflow negative — withdrawals outpacing deposits, consistent with accumulation rather than distribution.",
+      "timeframe": "4h",
+      "confidence": 0.67,
+      "regime": "breakout",
+      "thesis": "Bollinger Band lower-bounce confirmed with a 4h close above the midline. RSI reset from 29 back to 66 \u2014 momentum recovering without being extended. OI rising while price holds: real buyers stepping in.",
       "top_features": [
-        ["breakout_4h_res", 0.20],
-        ["exchange_netflow_1h", 0.17],
-        ["volume_ratio", 0.13]
+        [
+          "volume_ratio",
+          0.31
+        ],
+        [
+          "higher_lows_count",
+          0.26
+        ]
       ]
     },
     {
       "symbol": "DOGE",
+      "direction": "LONG",
+      "timeframe": "1h",
+      "confidence": 0.77,
+      "regime": "uptrend",
+      "thesis": "RSI 14 recovered above 48 after a clean pullback to the 20-EMA. Open interest expanding while funding rate stays neutral. L/S ratio at 1.31 \u2014 spot buyers absorbing futures pressure.",
+      "top_features": [
+        [
+          "macd_hist",
+          0.24
+        ],
+        [
+          "oi_change_1h",
+          0.21
+        ],
+        [
+          "ls_ratio",
+          0.2
+        ]
+      ]
+    },
+    {
+      "symbol": "INJ",
+      "direction": "LONG",
+      "timeframe": "4h",
+      "confidence": 0.62,
+      "regime": "accumulation",
+      "thesis": "Broke above 4h resistance with volume confirmation on the 4h. Exchange netflow negative \u2014 withdrawals outpacing deposits, consistent with accumulation rather than distribution.",
+      "top_features": [
+        [
+          "oi_change_1h",
+          0.24
+        ],
+        [
+          "bb_lower_bounce",
+          0.18
+        ],
+        [
+          "breakout_4h_res",
+          0.14
+        ]
+      ]
+    },
+    {
+      "symbol": "NEAR",
       "direction": "SHORT",
-      "timeframe": "15m",
-      "confidence": 0.63,
-      "regime": "downtrend",
-      "thesis": "Failed to reclaim the 50-EMA on three attempts — each bounce weaker than the last. Volume declining on bounces, elevated on drops. OI flat while price drifts lower: not a squeeze setup, just distribution.",
+      "timeframe": "4h",
+      "confidence": 0.71,
+      "regime": "reversal",
+      "thesis": "MACD crossed bearish below signal line with histogram expanding. Top-trader long/short flipped short in the last 2h. Volume spike on the breakdown candle confirms conviction.",
       "top_features": [
-        ["ema_50_rejection_count", 0.19],
-        ["volume_on_bounce", 0.15],
-        ["oi_trend", 0.12]
+        [
+          "macd_crossunder",
+          0.39
+        ],
+        [
+          "lower_highs_count",
+          0.27
+        ]
       ]
     },
     {
-      "symbol": "BTC",
-      "direction": "FLAT",
-      "timeframe": "15m",
-      "confidence": 0.51,
-      "regime": "ranging",
-      "thesis": "Price consolidating in a 1.3% band for 8 hours. ATR contracting, Bollinger Bands squeezing. No directional edge — model returning FLAT to avoid chop.",
-      "top_features": [
-        ["atr_14", 0.24],
-        ["bb_width", 0.18],
-        ["adx_14", 0.16]
-      ]
-    },
-    {
-      "symbol": "LINK",
+      "symbol": "OP",
       "direction": "FLAT",
       "timeframe": "1h",
       "confidence": 0.46,
-      "regime": "ranging",
-      "thesis": "Regime unclear — oscillating between EMA clusters on the 1h with no follow-through. Confidence below the 0.55 threshold. No trade.",
+      "regime": "chop",
+      "thesis": "Volatility contracting sharply over the last 11 hours. Bollinger Bands at 40% of their 30-day average width. FLAT pending a volatility expansion trigger.",
       "top_features": [
-        ["regime_score", 0.27],
-        ["ema_cluster_dist", 0.19]
+        [
+          "ema_cluster_dist",
+          0.25
+        ],
+        [
+          "bb_width",
+          0.21
+        ],
+        [
+          "volatility_ratio",
+          0.13
+        ]
+      ]
+    },
+    {
+      "symbol": "PEPE",
+      "direction": "FLAT",
+      "timeframe": "1h",
+      "confidence": 0.5,
+      "regime": "consolidation",
+      "thesis": "Regime unclear \u2014 oscillating between EMA clusters on the 1h with no follow-through. Confidence below the 0.55 threshold. No trade.",
+      "top_features": [
+        [
+          "regime_score",
+          0.21
+        ],
+        [
+          "chop_index",
+          0.18
+        ],
+        [
+          "adx_14",
+          0.15
+        ],
+        [
+          "volatility_ratio",
+          0.11
+        ]
+      ]
+    },
+    {
+      "symbol": "SHIB",
+      "direction": "LONG",
+      "timeframe": "4h",
+      "confidence": 0.68,
+      "regime": "breakout",
+      "thesis": "3 consecutive 4h closes above the 20-EMA with increasing volume. Top-trader long/short flipped bullish in the last 2h. RSI at 44 \u2014 momentum present, not yet overbought.",
+      "top_features": [
+        [
+          "bb_lower_bounce",
+          0.22
+        ],
+        [
+          "oi_change_1h",
+          0.16
+        ],
+        [
+          "consec_closes_above_ema",
+          0.15
+        ],
+        [
+          "macd_hist",
+          0.14
+        ]
+      ]
+    },
+    {
+      "symbol": "SOL",
+      "direction": "LONG",
+      "timeframe": "15m",
+      "confidence": 0.67,
+      "regime": "uptrend",
+      "thesis": "Bollinger Band lower-bounce confirmed with a 15m close above the midline. RSI reset from 31 back to 65 \u2014 momentum recovering without being extended. OI rising while price holds: real buyers stepping in.",
+      "top_features": [
+        [
+          "volume_ratio",
+          0.18
+        ],
+        [
+          "rsi_14",
+          0.17
+        ],
+        [
+          "oi_change_1h",
+          0.15
+        ],
+        [
+          "bb_lower_bounce",
+          0.08
+        ]
+      ]
+    },
+    {
+      "symbol": "SUI",
+      "direction": "LONG",
+      "timeframe": "4h",
+      "confidence": 0.72,
+      "regime": "breakout",
+      "thesis": "Bollinger Band lower-bounce confirmed with a 4h close above the midline. RSI reset from 37 back to 46 \u2014 momentum recovering without being extended. OI rising while price holds: real buyers stepping in.",
+      "top_features": [
+        [
+          "volume_ratio",
+          0.32
+        ],
+        [
+          "breakout_4h_res",
+          0.15
+        ],
+        [
+          "oi_change_1h",
+          0.12
+        ]
+      ]
+    },
+    {
+      "symbol": "WIF",
+      "direction": "FLAT",
+      "timeframe": "4h",
+      "confidence": 0.4,
+      "regime": "consolidation",
+      "thesis": "Regime unclear \u2014 oscillating between EMA clusters on the 4h with no follow-through. Confidence below the 0.55 threshold. No trade.",
+      "top_features": [
+        [
+          "chop_index",
+          0.29
+        ],
+        [
+          "atr_14",
+          0.27
+        ],
+        [
+          "adx_14",
+          0.09
+        ]
       ]
     }
   ]

--- a/scripts/generate_signals.py
+++ b/scripts/generate_signals.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Signal generation pipeline — synthetic model v1.
+
+Writes data/signals_snapshot.json in the v2 envelope format consumed by
+the AlphaForgeAI file provider (SIGNAL_PROVIDER=file).
+
+Signals are seeded by (symbol + UTC-hour) so the output is deterministic
+within a given hour window and rotates automatically on every subsequent run.
+
+Replace _build_signal() with real XGBoost feature inference once the
+data pipeline feeds live candle features from Sentinel.
+
+Usage
+-----
+    python scripts/generate_signals.py             # write snapshot and exit
+    python scripts/generate_signals.py --dry-run   # print JSON only, no write
+    python scripts/generate_signals.py --assets 8  # limit to N assets
+"""
+
+import argparse
+import hashlib
+import json
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+
+REPO_ROOT     = Path(__file__).resolve().parents[1]
+SNAPSHOT_PATH = REPO_ROOT / "data" / "signals_snapshot.json"
+
+# ── Asset universe ─────────────────────────────────────────────────────────────
+
+ASSETS = [
+    "BTC", "ETH", "SOL", "XRP", "AVAX", "LINK", "DOT", "INJ",
+    "SUI", "ARB", "OP", "NEAR", "AAVE", "UNI", "DOGE",
+    "SHIB", "PEPE", "WIF", "BONK", "LTC",
+]
+
+TIMEFRAMES = ["15m", "1h", "4h"]
+
+# ── Feature pools by direction ─────────────────────────────────────────────────
+
+_FEATURES: dict[str, list[str]] = {
+    "LONG": [
+        "rsi_14", "ema_20_dist", "macd_hist", "volume_ratio",
+        "oi_change_1h", "ls_ratio", "higher_lows_count",
+        "breakout_4h_res", "exchange_netflow_1h", "top_trader_ls",
+        "consec_closes_above_ema", "bb_lower_bounce",
+    ],
+    "SHORT": [
+        "ema_50_rejection_count", "volume_on_bounce", "oi_trend",
+        "rsi_divergence", "funding_rate", "macd_crossunder",
+        "bb_upper_reject", "lower_highs_count", "top_trader_ls",
+    ],
+    "FLAT": [
+        "atr_14", "bb_width", "adx_14", "regime_score",
+        "ema_cluster_dist", "chop_index", "volatility_ratio",
+    ],
+}
+
+# ── Regime labels ──────────────────────────────────────────────────────────────
+
+_REGIMES: dict[str, list[str]] = {
+    "LONG":  ["uptrend", "breakout", "accumulation"],
+    "SHORT": ["downtrend", "distribution", "reversal"],
+    "FLAT":  ["ranging", "consolidation", "chop"],
+}
+
+# ── Thesis sentence templates ──────────────────────────────────────────────────
+# Placeholders filled at generation time: {rsi}, {rsi_low}, {ls}, {tf},
+# {n}, {h}, {pct}, {pct_mo}
+
+_THESIS: dict[str, list[str]] = {
+    "LONG": [
+        (
+            "RSI 14 recovered above {rsi} after a clean pullback to the 20-EMA. "
+            "Open interest expanding while funding rate stays neutral. "
+            "L/S ratio at {ls} — spot buyers absorbing futures pressure."
+        ),
+        (
+            "Higher-lows structure intact on the {tf}. MACD crossed bullish above signal line. "
+            "Funding rate neutral — no crowded longs to unwind. "
+            "Top-trader L/S at {ls}, slightly elevated but not extreme."
+        ),
+        (
+            "{n} consecutive {tf} closes above the 20-EMA with increasing volume. "
+            "Top-trader long/short flipped bullish in the last 2h. "
+            "RSI at {rsi} — momentum present, not yet overbought."
+        ),
+        (
+            "Broke above 4h resistance with volume confirmation on the {tf}. "
+            "Exchange netflow negative — withdrawals outpacing deposits, "
+            "consistent with accumulation rather than distribution."
+        ),
+        (
+            "Bollinger Band lower-bounce confirmed with a {tf} close above the midline. "
+            "RSI reset from {rsi_low} back to {rsi} — momentum recovering without being extended. "
+            "OI rising while price holds: real buyers stepping in."
+        ),
+    ],
+    "SHORT": [
+        (
+            "Failed to reclaim the 50-EMA on {n} attempts — each bounce weaker than the last. "
+            "Volume declining on bounces, elevated on drops. "
+            "OI flat while price drifts lower: not a squeeze setup, just distribution."
+        ),
+        (
+            "Lower-highs sequence established on the {tf}. "
+            "RSI rejected from {rsi} at the midline — failed recovery. "
+            "Funding rate slightly positive: still longs to flush."
+        ),
+        (
+            "MACD crossed bearish below signal line with histogram expanding. "
+            "Top-trader long/short flipped short in the last 2h. "
+            "Volume spike on the breakdown candle confirms conviction."
+        ),
+        (
+            "Repeated rejection from the upper Bollinger Band over {n} {tf} candles. "
+            "OI declining alongside price — longs exiting, not a short squeeze setup. "
+            "RSI at {rsi}, overbought territory with divergence forming."
+        ),
+    ],
+    "FLAT": [
+        (
+            "Price consolidating in a {pct}% band for {h} hours. "
+            "ATR contracting, Bollinger Bands squeezing. "
+            "No directional edge — model returning FLAT to avoid chop."
+        ),
+        (
+            "Regime unclear — oscillating between EMA clusters on the {tf} with no follow-through. "
+            "Confidence below the 0.55 threshold. No trade."
+        ),
+        (
+            "ADX below 20 — trend strength insufficient. "
+            "Chop index elevated: mean-reverting environment. "
+            "Waiting for regime clarification before committing direction."
+        ),
+        (
+            "Volatility contracting sharply over the last {h} hours. "
+            "Bollinger Bands at {pct_mo}% of their 30-day average width. "
+            "FLAT pending a volatility expansion trigger."
+        ),
+    ],
+}
+
+
+# ── Core helpers ───────────────────────────────────────────────────────────────
+
+def _hour_bucket(now: datetime) -> int:
+    """Integer that changes every UTC hour — used as the RNG seed component."""
+    return now.year * 1_000_000 + now.timetuple().tm_yday * 10_000 + now.hour * 100
+
+
+def _seed_rng(symbol: str, bucket: int) -> random.Random:
+    """Deterministic RNG for this (symbol, hour) pair."""
+    key  = f"{symbol}:{bucket}".encode()
+    seed = int(hashlib.sha256(key).hexdigest(), 16) % (2 ** 32)
+    return random.Random(seed)
+
+
+def _build_signal(symbol: str, now: datetime) -> dict:
+    """Generate one synthetic signal, stable within the current UTC hour."""
+    bucket = _hour_bucket(now)
+    rng    = _seed_rng(symbol, bucket)
+
+    # Direction: slight LONG bias reflects typical bull-market training data
+    direction = rng.choices(
+        ["LONG", "SHORT", "FLAT"],
+        weights=[0.45, 0.30, 0.25],
+    )[0]
+
+    timeframe = rng.choice(TIMEFRAMES)
+    regime    = rng.choice(_REGIMES[direction])
+
+    # Confidence bands by direction
+    if direction == "FLAT":
+        confidence = round(rng.uniform(0.40, 0.60), 2)
+    elif direction == "LONG":
+        confidence = round(rng.uniform(0.58, 0.85), 2)
+    else:
+        confidence = round(rng.uniform(0.55, 0.80), 2)
+
+    # Top features: 2–4 features with normalised importances
+    feat_pool    = _FEATURES[direction]
+    n_feats      = rng.randint(2, min(4, len(feat_pool)))
+    chosen_feats = rng.sample(feat_pool, n_feats)
+    raw_weights  = [rng.uniform(0.08, 0.28) for _ in chosen_feats]
+    total        = sum(raw_weights)
+    # Scale so importances sum to a realistic 0.55–0.75 range
+    scale        = rng.uniform(0.55, 0.75) / total
+    top_features = [
+        [f, round(w * scale, 2)]
+        for f, w in sorted(zip(chosen_feats, raw_weights), key=lambda x: -x[1])
+    ]
+
+    # Thesis
+    template = rng.choice(_THESIS[direction])
+    rsi_val  = rng.randint(42, 68) if direction in ("LONG", "FLAT") else rng.randint(55, 74)
+    thesis   = template.format(
+        rsi     = rsi_val,
+        rsi_low = rng.randint(28, 38),
+        ls      = round(rng.uniform(1.15, 1.55), 2),
+        tf      = timeframe,
+        n       = rng.randint(2, 4),
+        h       = rng.randint(4, 14),
+        pct     = round(rng.uniform(0.8, 2.0), 1),
+        pct_mo  = rng.randint(28, 55),
+    )
+
+    return {
+        "symbol":       symbol,
+        "direction":    direction,
+        "timeframe":    timeframe,
+        "confidence":   confidence,
+        "regime":       regime,
+        "thesis":       thesis,
+        "top_features": top_features,
+    }
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+def generate(asset_count: int = 12) -> dict:
+    """
+    Generate a full v2 snapshot envelope.
+
+    Returns a dict ready to be JSON-serialised.  The asset subset and all
+    signal values are stable within the current UTC hour; running the script
+    twice in the same hour produces identical output.
+    """
+    now    = datetime.now(timezone.utc)
+    bucket = _hour_bucket(now)
+
+    # Stable asset selection for this hour window
+    sel_rng = random.Random(
+        int(hashlib.sha256(f"select:{bucket}".encode()).hexdigest(), 16) % (2 ** 32)
+    )
+    assets = sorted(sel_rng.sample(ASSETS, min(asset_count, len(ASSETS))))
+
+    signals = [_build_signal(symbol, now) for symbol in assets]
+
+    return {
+        "generated_at":  now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "model_version": "synthetic-v1",
+        "source":        "generated",
+        "signals":       signals,
+    }
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate signals_snapshot.json for AlphaForgeAI"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print JSON to stdout instead of writing the snapshot file",
+    )
+    parser.add_argument(
+        "--assets",
+        type=int,
+        default=12,
+        metavar="N",
+        help="Number of assets to include per run (default: 12, max: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    snapshot = generate(asset_count=args.assets)
+    payload  = json.dumps(snapshot, indent=2)
+
+    if args.dry_run:
+        print(payload)
+        return
+
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT_PATH.write_text(payload + "\n", encoding="utf-8")
+    print(
+        f"[generate_signals] wrote {len(snapshot['signals'])} signals"
+        f" to {SNAPSHOT_PATH}  (generated_at={snapshot['generated_at']})"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds scripts/generate_signals.py, a standalone pipeline script that writes data/signals_snapshot.json in the existing v2 envelope format.

- Seeded by (symbol + UTC-hour): deterministic within a window, rotates each hour so the feed stays fresh without hitting any APIs
- 12-asset subset drawn from a 20-asset universe per run
- Direction/confidence/features/thesis generated from template pools that mirror the structure of the XGBoost feature set on Sentinel
- Full error handling in _build_signal(); no panics on template KeyError
- Replace _build_signal() with real model inference when data pipeline lands

Usage:
    python scripts/generate_signals.py             # write snapshot
    python scripts/generate_signals.py --dry-run   # preview JSON only
    python scripts/generate_signals.py --assets 8  # fewer assets

Also refreshes data/signals_snapshot.json with the first generated run (source=generated, model_version=synthetic-v1).