### PR TITLE
Add PR smoke tests for health and signals routes

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: python -m pip install -r requirements.txt
 
+      - name: Generate signal snapshot
+        run: python scripts/generate_signals.py
+
       - name: Start app
         run: |
           python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1 &

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -1,0 +1,67 @@
+name: PR smoke tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  smoke:
+    name: FastAPI route smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      ENVIRONMENT: production
+      SIGNAL_PROVIDER: file
+      SIGNAL_FILE_PATH: data/signals/latest.json
+      ALLOW_MOCK_FALLBACK: "false"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Start app
+        run: |
+          python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1 &
+          echo $! > uvicorn.pid
+
+          for i in {1..20}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8000/health > /tmp/health.json; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat uvicorn.log
+          exit 1
+
+      - name: Smoke /health
+        run: |
+          curl --fail --silent --show-error http://127.0.0.1:8000/health | tee /tmp/health.json
+          python -m json.tool /tmp/health.json > /dev/null
+          python -c "import json; data=json.load(open('/tmp/health.json')); assert data['status'] == 'ok'; assert data['signal_engine']['healthy'] is True"
+
+      - name: Smoke /signals
+        run: |
+          curl --fail --silent --show-error http://127.0.0.1:8000/signals > /tmp/signals.html
+          test -s /tmp/signals.html
+          grep -q "Signal Feed" /tmp/signals.html
+
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -f uvicorn.pid ]; then
+            kill "$(cat uvicorn.pid)" || true
+          fi
+          cat uvicorn.log || true

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -40,6 +40,11 @@ jobs:
           echo $! > uvicorn.pid
 
           for i in {1..20}; do
+            if ! kill -0 "$(cat uvicorn.pid)" 2>/dev/null; then
+              echo "uvicorn exited early"
+              cat uvicorn.log
+              exit 1
+            fi
             if curl --fail --silent --show-error http://127.0.0.1:8000/health > /tmp/health.json; then
               exit 0
             fi
@@ -53,13 +58,30 @@ jobs:
         run: |
           curl --fail --silent --show-error http://127.0.0.1:8000/health | tee /tmp/health.json
           python -m json.tool /tmp/health.json > /dev/null
-          python -c "import json; data=json.load(open('/tmp/health.json')); assert data['status'] == 'ok'; assert data['signal_engine']['healthy'] is True"
+          python -c "
+import json, sys
+data = json.load(open('/tmp/health.json'))
+if data.get('status') != 'ok' or data.get('signal_engine', {}).get('healthy') is not True:
+    print('FAIL - /health response:')
+    print(json.dumps(data, indent=2))
+    sys.exit(1)
+"
 
       - name: Smoke /signals
         run: |
           curl --fail --silent --show-error http://127.0.0.1:8000/signals > /tmp/signals.html
           test -s /tmp/signals.html
           grep -q "Signal Feed" /tmp/signals.html
+          python -c "
+import re, sys
+html = open('/tmp/signals.html').read()
+counts = re.findall(r'(\d+)\s+signals?', html, re.IGNORECASE)
+total = int(counts[0]) if counts else 0
+if total == 0:
+    print('FAIL - no signals rendered in /signals page')
+    sys.exit(1)
+print(f'OK - {total} signal(s) rendered')
+"
 
       - name: Stop app
         if: always()


### PR DESCRIPTION
## Summary
- add a lightweight GitHub Actions workflow for PR route smoke tests
- install Python dependencies, start the FastAPI app locally, and hit `/health` and `/signals`
- assert `/health` returns JSON `status=ok` with a healthy signal engine and `/signals` renders non-empty HTML

## Verification
- local equivalent: `route_smoke_ok` via FastAPI TestClient for `/health` and `/signals`

Closes #23