### PR TITLE
Schedule signal snapshot refresh

### DIFF
--- a/.github/workflows/refresh-signals.yml
+++ b/.github/workflows/refresh-signals.yml
@@ -1,0 +1,99 @@
+name: Refresh signals snapshot
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+    inputs:
+      assets:
+        description: "Number of assets to generate"
+        required: false
+        default: "12"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-signals-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Generate and persist latest signals
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      ENVIRONMENT: production
+      SIGNAL_PROVIDER: file
+      SIGNAL_FILE_PATH: data/signals/latest.json
+      ALLOW_MOCK_FALLBACK: "false"
+      ASSET_COUNT: ${{ github.event.inputs.assets || '12' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Generate latest snapshot
+        run: |
+          set -euo pipefail
+          echo "[refresh-signals] starting refresh at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "[refresh-signals] asset_count=${ASSET_COUNT}"
+          python scripts/generate_signals.py --assets "${ASSET_COUNT}"
+          python -m json.tool data/signals/latest.json > /tmp/latest.json
+          echo "[refresh-signals] snapshot generated and JSON validated"
+
+      - name: Smoke generated snapshot
+        run: |
+          set -euo pipefail
+          python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1 &
+          echo $! > uvicorn.pid
+
+          for i in {1..20}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8000/health > /tmp/health.json; then
+              break
+            fi
+            sleep 1
+          done
+
+          curl --fail --silent --show-error http://127.0.0.1:8000/health | tee /tmp/health.json
+          python -c "import json; data=json.load(open('/tmp/health.json')); assert data['status'] == 'ok'; assert data['signal_engine']['healthy'] is True"
+
+          curl --fail --silent --show-error http://127.0.0.1:8000/signals > /tmp/signals.html
+          test -s /tmp/signals.html
+          grep -q "Signal Feed" /tmp/signals.html
+          echo "[refresh-signals] route smoke passed"
+
+      - name: Stop app
+        if: always()
+        run: |
+          if [ -f uvicorn.pid ]; then
+            kill "$(cat uvicorn.pid)" || true
+          fi
+          cat uvicorn.log || true
+
+      - name: Commit refreshed snapshot
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- data/signals/latest.json; then
+            echo "[refresh-signals] no snapshot changes to commit"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/signals/latest.json
+          git commit -m "chore: refresh generated signals snapshot"
+          git push
+          echo "[refresh-signals] committed refreshed snapshot"

--- a/.github/workflows/refresh-signals.yml
+++ b/.github/workflows/refresh-signals.yml
@@ -95,5 +95,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add data/signals/latest.json
           git commit -m "chore: refresh generated signals snapshot"
-          git push
+          git push origin HEAD
           echo "[refresh-signals] committed refreshed snapshot"

--- a/.github/workflows/refresh-signals.yml
+++ b/.github/workflows/refresh-signals.yml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -51,10 +49,10 @@ jobs:
           echo "[refresh-signals] starting refresh at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo "[refresh-signals] asset_count=${ASSET_COUNT}"
           python scripts/generate_signals.py --assets "${ASSET_COUNT}"
-          python -m json.tool data/signals/latest.json > /tmp/latest.json
+          python -m json.tool data/signals/latest.json > /dev/null
           echo "[refresh-signals] snapshot generated and JSON validated"
 
-      - name: Smoke generated snapshot
+      - name: Start app
         run: |
           set -euo pipefail
           python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1 &
@@ -62,12 +60,16 @@ jobs:
 
           for i in {1..20}; do
             if curl --fail --silent --show-error http://127.0.0.1:8000/health > /tmp/health.json; then
-              break
+              exit 0
             fi
             sleep 1
           done
+          cat uvicorn.log
+          exit 1
 
-          curl --fail --silent --show-error http://127.0.0.1:8000/health | tee /tmp/health.json
+      - name: Smoke routes
+        run: |
+          set -euo pipefail
           python -c "import json; data=json.load(open('/tmp/health.json')); assert data['status'] == 'ok'; assert data['signal_engine']['healthy'] is True"
 
           curl --fail --silent --show-error http://127.0.0.1:8000/signals > /tmp/signals.html

--- a/docs/signal-refresh.md
+++ b/docs/signal-refresh.md
@@ -1,0 +1,15 @@
+# Signal Refresh
+
+The generated signal snapshot is refreshed by GitHub Actions.
+
+- Workflow: `.github/workflows/refresh-signals.yml`
+- Schedule: hourly at minute 17 UTC
+- Manual run: GitHub Actions -> Refresh signals snapshot -> Run workflow
+- Output: `data/signals/latest.json`
+
+The workflow reuses `scripts/generate_signals.py`, validates the generated JSON,
+starts the FastAPI app locally, and smoke checks `/health` and `/signals`.
+
+The generator writes through an atomic temp-file path. If generation, validation,
+or route smoke checks fail, the workflow stops before committing, so the last
+known good snapshot stays in place.


### PR DESCRIPTION
## Summary
- add a GitHub Actions cron workflow to refresh `data/signals/latest.json` hourly
- add `workflow_dispatch` with an optional asset count input for manual refreshes
- reuse `scripts/generate_signals.py` and the existing atomic snapshot write path
- validate generated JSON, smoke `/health` and `/signals`, then commit only if all checks pass
- document the schedule, manual run path, and last-known-good behavior

## Safety
If generation, JSON validation, or route smoke checks fail, the workflow exits before committing. The repository keeps the last known good snapshot.

## Verification
- `python scripts\generate_signals.py --dry-run | python -m json.tool`
- local equivalent route smoke for `/health` and `/signals`: `route_smoke_ok`

Closes #12