### PR TITLE
Add signal staleness handling

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -22,6 +22,12 @@ class Settings:
     signal_freshness_warn_hours: int = field(
         default_factory=lambda: int(os.getenv("SIGNAL_FRESHNESS_WARN_HOURS", "24"))
     )
+    signal_stale_after_hours: int = field(
+        default_factory=lambda: int(os.getenv("SIGNAL_STALE_AFTER_HOURS", "48"))
+    )
+    signal_stale_action: str = field(
+        default_factory=lambda: os.getenv("SIGNAL_STALE_ACTION", "mark").strip().lower()
+    )
 
     # ── Sentinel SSH connection ──────────────────────────────────────────────
     # Required when signal_source == "sentinel_ssh".

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -7,6 +7,10 @@ from fastapi.templating import Jinja2Templates
 
 from app.core.config import settings
 from app.repositories.signal_repository import get_signals_from_file
+from app.services.signal_staleness import (
+    evaluate_signal_staleness,
+    parse_utc_timestamp,
+)
 
 router = APIRouter()
 
@@ -14,14 +18,7 @@ templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "tem
 
 
 def _parse_utc_timestamp(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(
-            timezone.utc
-        )
-    except ValueError:
-        return None
+    return parse_utc_timestamp(value)
 
 
 def _signal_engine_health() -> dict:
@@ -53,6 +50,12 @@ def _signal_engine_health() -> dict:
             "age_seconds": None,
             "warn_after_hours": settings.signal_freshness_warn_hours,
         },
+        "staleness": {
+            "is_stale": False,
+            "action": settings.signal_stale_action,
+            "age_seconds": None,
+            "stale_after_hours": settings.signal_stale_after_hours,
+        },
         "refresh_job": {
             "configured": False,
             "status": "not_configured",
@@ -77,6 +80,13 @@ def _signal_engine_health() -> dict:
         else len(snapshot.signals)
     )
     engine["schema_version"] = snapshot.schema_version
+    staleness = evaluate_signal_staleness(snapshot.generated_at)
+    engine["staleness"] = {
+        "is_stale": staleness.is_stale,
+        "action": staleness.action,
+        "age_seconds": staleness.age_seconds,
+        "stale_after_hours": staleness.stale_after_hours,
+    }
 
     generated_at = _parse_utc_timestamp(snapshot.generated_at)
     if generated_at:

--- a/app/routes/signals.py
+++ b/app/routes/signals.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from app.core.config import settings
 from app.services.signal_service import get_signals
+from app.services.signal_staleness import evaluate_signal_staleness
 
 router = APIRouter()
 
@@ -14,7 +15,10 @@ templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "tem
 @router.get("/signals", response_class=HTMLResponse)
 async def signal_feed(request: Request):
     snapshot = get_signals()
-    signals  = snapshot.signals
+    staleness = evaluate_signal_staleness(snapshot.generated_at)
+    signals = []
+    if not (staleness.is_stale and staleness.action == "filter"):
+        signals = snapshot.signals
 
     # Format generated_at for display ("2026-04-22T12:00:00Z" → "2026-04-22 12:00 UTC")
     generated_at_display: str | None = None
@@ -47,6 +51,9 @@ async def signal_feed(request: Request):
         "generated_at":       generated_at_display,
         "model_version":      snapshot.model_version,
         "used_mock_fallback": snapshot.used_mock_fallback,
+        "signals_stale":      staleness.is_stale,
+        "stale_action":       staleness.action,
+        "stale_after_hours":  staleness.stale_after_hours,
         # observability
         "snapshot_status":    snapshot.status,
         "error_message":      snapshot.error_message,

--- a/app/services/signal_staleness.py
+++ b/app/services/signal_staleness.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from app.core.config import settings
+
+
+@dataclass(frozen=True)
+class SignalStaleness:
+    is_stale: bool
+    action: str
+    age_seconds: int | None
+    stale_after_hours: int
+
+
+def parse_utc_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(
+            timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+def evaluate_signal_staleness(generated_at: str | None) -> SignalStaleness:
+    generated = parse_utc_timestamp(generated_at)
+    age_seconds: int | None = None
+    is_stale = False
+
+    if generated:
+        age_seconds = max(
+            int((datetime.now(timezone.utc) - generated).total_seconds()),
+            0,
+        )
+        is_stale = age_seconds > settings.signal_stale_after_hours * 3600
+
+    action = settings.signal_stale_action
+    if action not in {"mark", "filter"}:
+        action = "mark"
+
+    return SignalStaleness(
+        is_stale=is_stale,
+        action=action,
+        age_seconds=age_seconds,
+        stale_after_hours=settings.signal_stale_after_hours,
+    )

--- a/app/templates/signals.html
+++ b/app/templates/signals.html
@@ -41,7 +41,8 @@
     {% endif %}
     <span class="source-meta-sep">&middot;</span>
     <span class="source-meta-item source-meta-status">
-        {% if snapshot_status == 'ok' %}live
+        {% if signals_stale %}stale
+        {% elif snapshot_status == 'ok' %}live
         {% elif snapshot_status == 'empty' %}empty
         {% elif snapshot_status == 'error' %}source error
         {% elif snapshot_status == 'fallback' %}mock fallback
@@ -72,6 +73,15 @@
     {# Source responded but had no signals — production honest-empty state #}
     <div class="snapshot-notice snapshot-notice-warn">
         &#9888; No signals available. The snapshot is empty or the source returned no records.
+    </div>
+{% elif signals_stale %}
+    <div class="snapshot-notice snapshot-notice-warn">
+        &#9888; Signals are older than {{ stale_after_hours }} hours.
+        {% if stale_action == 'filter' %}
+            Stale signals are hidden until the next successful refresh.
+        {% else %}
+            Displaying stale signals until the next successful refresh.
+        {% endif %}
     </div>
 {% else %}
     {# status == "ok" — normal operational state #}

--- a/tests/test_signal_health.py
+++ b/tests/test_signal_health.py
@@ -39,13 +39,19 @@ class SignalHealthTests(unittest.TestCase):
             "signal_provider": settings.signal_provider,
             "signal_file_path": settings.signal_file_path,
             "signal_freshness_warn_hours": settings.signal_freshness_warn_hours,
+            "signal_stale_after_hours": settings.signal_stale_after_hours,
+            "signal_stale_action": settings.signal_stale_action,
         }
         self._allow_mock_fallback = os.environ.get("ALLOW_MOCK_FALLBACK")
 
     def tearDown(self) -> None:
         settings.signal_provider = self._settings["signal_provider"]
         settings.signal_file_path = self._settings["signal_file_path"]
-        settings.signal_freshness_warn_hours = self._settings["signal_freshness_warn_hours"]
+        settings.signal_freshness_warn_hours = self._settings[
+            "signal_freshness_warn_hours"
+        ]
+        settings.signal_stale_after_hours = self._settings["signal_stale_after_hours"]
+        settings.signal_stale_action = self._settings["signal_stale_action"]
         if self._allow_mock_fallback is None:
             os.environ.pop("ALLOW_MOCK_FALLBACK", None)
         else:
@@ -92,6 +98,55 @@ class SignalHealthTests(unittest.TestCase):
         self.assertFalse(body["signal_engine"]["healthy"])
         self.assertFalse(body["signal_engine"]["snapshot"]["present"])
         self.assertIn("Signal file not found", body["signal_engine"]["error"])
+
+    def test_health_reports_stale_snapshot_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            stale = _snapshot()
+            stale["generated_at"] = "2020-01-01T00:00:00Z"
+            path = Path(tmp) / "latest.json"
+            path.write_text(json.dumps(stale), encoding="utf-8")
+            settings.signal_provider = "file"
+            settings.signal_file_path = str(path)
+            settings.signal_stale_after_hours = 1
+
+            body = self.client.get("/health").json()
+
+        self.assertTrue(body["signal_engine"]["staleness"]["is_stale"])
+        self.assertEqual(body["signal_engine"]["staleness"]["stale_after_hours"], 1)
+
+    def test_signals_marks_stale_snapshot_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            stale = _snapshot()
+            stale["generated_at"] = "2020-01-01T00:00:00Z"
+            path = Path(tmp) / "latest.json"
+            path.write_text(json.dumps(stale), encoding="utf-8")
+            settings.signal_provider = "file"
+            settings.signal_file_path = str(path)
+            settings.signal_stale_after_hours = 1
+            settings.signal_stale_action = "mark"
+
+            response = self.client.get("/signals")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Signals are older than 1 hours", response.text)
+        self.assertIn("ETH", response.text)
+
+    def test_signals_filters_stale_snapshot_when_configured(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            stale = _snapshot()
+            stale["generated_at"] = "2020-01-01T00:00:00Z"
+            path = Path(tmp) / "latest.json"
+            path.write_text(json.dumps(stale), encoding="utf-8")
+            settings.signal_provider = "file"
+            settings.signal_file_path = str(path)
+            settings.signal_stale_after_hours = 1
+            settings.signal_stale_action = "filter"
+
+            response = self.client.get("/signals")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Stale signals are hidden", response.text)
+        self.assertNotIn("Test signal.", response.text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add configurable signal staleness threshold with `SIGNAL_STALE_AFTER_HOURS` (default 48)
- add configurable stale behavior with `SIGNAL_STALE_ACTION=mark|filter` (default mark)
- mark stale snapshots in `/signals` with the existing warning notice style, or hide stale cards when configured to filter
- expose staleness metadata in `/health` signal engine details
- keep existing snapshot fallback behavior, health checks, and smoke test expectations intact

## Verification
- `python -m unittest tests.test_signal_health tests.test_snapshot_persistence`
- `python -m py_compile app\core\config.py app\routes\pages.py app\routes\signals.py app\services\signal_staleness.py tests\test_signal_health.py`
- default route smoke: `route_smoke_ok`
- forced stale filter smoke: `stale_filter_ok`

Closes #15