### PR TITLE
Add signal confidence calibration layer

### DIFF
--- a/app/routes/signals.py
+++ b/app/routes/signals.py
@@ -4,12 +4,22 @@ from fastapi.templating import Jinja2Templates
 from pathlib import Path
 
 from app.core.config import settings
+from app.services.confidence_calibration import (
+    confidence_css_class,
+    confidence_label,
+    confidence_percent,
+    normalize_percent,
+)
 from app.services.signal_service import get_signals
 from app.services.signal_staleness import evaluate_signal_staleness
 
 router = APIRouter()
 
 templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "templates")
+templates.env.filters["confidence_percent"] = confidence_percent
+templates.env.filters["confidence_label"] = confidence_label
+templates.env.filters["confidence_css_class"] = confidence_css_class
+templates.env.filters["importance_percent"] = normalize_percent
 
 
 @router.get("/signals", response_class=HTMLResponse)

--- a/app/services/confidence_calibration.py
+++ b/app/services/confidence_calibration.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CalibratedConfidence:
+    percent: int
+    label: str
+    css_class: str
+
+
+def normalize_percent(value: float | int | None) -> int:
+    """
+    Normalize confidence or feature importance to a 0-100 integer.
+
+    Current snapshots store confidence as 0.0-1.0. This also accepts future
+    0-100 values without double-scaling them.
+    """
+    if value is None:
+        return 0
+
+    numeric = float(value)
+    if numeric <= 1:
+        numeric *= 100
+
+    return max(0, min(100, round(numeric)))
+
+
+def calibrate_confidence(value: float | int | None) -> CalibratedConfidence:
+    percent = normalize_percent(value)
+
+    if percent >= 80:
+        return CalibratedConfidence(percent=percent, label="High", css_class="high")
+    if percent >= 65:
+        return CalibratedConfidence(percent=percent, label="Medium", css_class="mid")
+    return CalibratedConfidence(percent=percent, label="Low", css_class="low")
+
+
+def confidence_percent(value: float | int | None) -> int:
+    return calibrate_confidence(value).percent
+
+
+def confidence_label(value: float | int | None) -> str:
+    return calibrate_confidence(value).label
+
+
+def confidence_css_class(value: float | int | None) -> str:
+    return calibrate_confidence(value).css_class

--- a/app/templates/signals.html
+++ b/app/templates/signals.html
@@ -108,10 +108,13 @@
             <div class="signal-right">
                 <div class="confidence-wrap">
                     <div class="confidence-bar">
-                        <div class="confidence-fill conf-{{ 'high' if signal.confidence >= 0.70 else ('mid' if signal.confidence >= 0.55 else 'low') }}"
-                             style="width: {{ (signal.confidence * 100) | round | int }}%"></div>
+                        <div class="confidence-fill conf-{{ signal.confidence | confidence_css_class }}"
+                             style="width: {{ signal.confidence | confidence_percent }}%"></div>
                     </div>
-                    <span class="confidence-label">{{ (signal.confidence * 100) | round | int }}% conf.</span>
+                    <span class="confidence-label">
+                        {{ signal.confidence | confidence_percent }}%
+                        {{ signal.confidence | confidence_label }}
+                    </span>
                 </div>
                 <span class="regime-tag">{{ signal.regime }}</span>
             </div>
@@ -124,7 +127,7 @@
             <span class="feature-label">Top features:</span>
             {% for name, weight in signal.top_features %}
             <span class="feature-chip">
-                {{ name }} <span class="feature-weight">{{ (weight * 100) | round | int }}%</span>
+                {{ name }} <span class="feature-weight">{{ weight | importance_percent }}%</span>
             </span>
             {% endfor %}
         </div>

--- a/tests/test_confidence_calibration.py
+++ b/tests/test_confidence_calibration.py
@@ -1,0 +1,27 @@
+import unittest
+
+from app.services.confidence_calibration import (
+    calibrate_confidence,
+    normalize_percent,
+)
+
+
+class ConfidenceCalibrationTests(unittest.TestCase):
+    def test_normalizes_fractional_confidence_to_percent(self) -> None:
+        self.assertEqual(normalize_percent(0.74), 74)
+
+    def test_accepts_existing_percent_scale(self) -> None:
+        self.assertEqual(normalize_percent(82), 82)
+
+    def test_clamps_to_percent_bounds(self) -> None:
+        self.assertEqual(normalize_percent(-0.5), 0)
+        self.assertEqual(normalize_percent(120), 100)
+
+    def test_confidence_thresholds_are_standardized(self) -> None:
+        self.assertEqual(calibrate_confidence(0.80).label, "High")
+        self.assertEqual(calibrate_confidence(0.65).label, "Medium")
+        self.assertEqual(calibrate_confidence(0.64).label, "Low")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small confidence calibration helper that normalizes confidence and feature importance to 0-100
- standardize display thresholds: 80+ High, 65-79 Medium, below 65 Low
- wire calibration into `/signals` via Jinja filters without redesigning the card UI
- keep feature importance visible and normalized through the same percent helper

## Verification
- `python -m unittest tests.test_confidence_calibration tests.test_signal_health tests.test_snapshot_persistence`
- `python -m py_compile app\routes\signals.py app\services\confidence_calibration.py tests\test_confidence_calibration.py`
- route smoke: `route_smoke_ok`

Closes #14