### PR TITLE
fix: three-state freshness status (fresh/warn/stale)

### DIFF
--- a/app/routes/dashboard.py
+++ b/app/routes/dashboard.py
@@ -12,8 +12,7 @@ templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "tem
 
 @router.get("/dashboard", response_class=HTMLResponse)
 async def dashboard(request: Request):
-    return templates.TemplateResponse("dashboard.html", {
-        "request":      request,
+    return templates.TemplateResponse(request, "dashboard.html", {
         "active_page":  "dashboard",
         "app_version":  settings.app_version,
         "environment":  settings.environment,

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -114,8 +114,7 @@ def _signal_engine_health() -> dict:
 
 @router.get("/", response_class=HTMLResponse)
 async def homepage(request: Request):
-    return templates.TemplateResponse("index.html", {
-        "request":      request,
+    return templates.TemplateResponse(request, "index.html", {
         "active_page":  "home",
         "app_version":  settings.app_version,
         "environment":  settings.environment,

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -92,11 +92,14 @@ def _signal_engine_health() -> dict:
     if generated_at:
         age_seconds = int((datetime.now(timezone.utc) - generated_at).total_seconds())
         engine["freshness"]["age_seconds"] = max(age_seconds, 0)
-        engine["freshness"]["status"] = (
-            "stale"
-            if age_seconds > settings.signal_freshness_warn_hours * 3600
-            else "fresh"
-        )
+        warn_seconds = settings.signal_freshness_warn_hours * 3600
+        stale_seconds = settings.signal_stale_after_hours * 3600
+        if age_seconds >= stale_seconds:
+            engine["freshness"]["status"] = "stale"
+        elif age_seconds >= warn_seconds:
+            engine["freshness"]["status"] = "warn"
+        else:
+            engine["freshness"]["status"] = "fresh"
     elif snapshot_present:
         engine["freshness"]["status"] = "unknown"
 

--- a/app/routes/signals.py
+++ b/app/routes/signals.py
@@ -45,8 +45,7 @@ async def signal_feed(request: Request):
         if generated_at_display and generated_at_display.endswith(":00 UTC"):
             generated_at_display = generated_at_display[:-7] + " UTC"
 
-    return templates.TemplateResponse("signals.html", {
-        "request":            request,
+    return templates.TemplateResponse(request, "signals.html", {
         "active_page":        "signals",
         "app_version":        settings.app_version,
         "environment":        settings.environment,


### PR DESCRIPTION
## Summary

- `_signal_engine_health()` was using `signal_freshness_warn_hours` as the threshold for `"stale"`, so `freshness.status` jumped directly from `"fresh"` to `"stale"` with no intermediate state
- Added a proper three-state check: `fresh` → `warn` → `stale`
  - `age < warn_hours * 3600` → `"fresh"`
  - `warn_hours * 3600 <= age < stale_hours * 3600` → `"warn"`
  - `age >= stale_hours * 3600` → `"stale"`
- Uses the already-configured `signal_stale_after_hours` setting for the stale threshold

## Test plan

- [ ] Verify `freshness.status == "fresh"` for a recently generated snapshot
- [ ] Verify `freshness.status == "warn"` when age is between `SIGNAL_FRESHNESS_WARN_HOURS` and `SIGNAL_STALE_AFTER_HOURS`
- [ ] Verify `freshness.status == "stale"` when age exceeds `SIGNAL_STALE_AFTER_HOURS`
- [ ] Existing `test_signal_health.py` tests pass

https://claude.ai/code/session_011hBNWSW5S5qko2G16GZFUK

---
_Generated by [Claude Code](https://claude.ai/code/session_011hBNWSW5S5qko2G16GZFUK)_