### PR TITLE
feat: unit tests for signal scoring + structured logging (#22, #19)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m pytest tests/ -v --tb=short

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -45,6 +45,18 @@ class Settings:
         ).strip().lower() in ("1", "true", "yes")
     )
 
+    # ── Confluence engine ────────────────────────────────────────────────────
+    # SIGNAL_CONFLUENCE=true  → run the multi-TF confluence engine after load
+    # SIGNAL_CONFLUENCE_FILTER=true → only return confluent signals (full/partial)
+    signal_confluence: bool = field(
+        default_factory=lambda: os.getenv("SIGNAL_CONFLUENCE", "false").strip().lower()
+        in ("1", "true", "yes")
+    )
+    signal_confluence_filter: bool = field(
+        default_factory=lambda: os.getenv("SIGNAL_CONFLUENCE_FILTER", "false").strip().lower()
+        in ("1", "true", "yes")
+    )
+
     # ── Derived properties ───────────────────────────────────────────────────
 
     @property

--- a/app/domain/signals.py
+++ b/app/domain/signals.py
@@ -19,6 +19,7 @@ class Direction(str, Enum):
 
 
 class Timeframe(str, Enum):
+    M5  = "5m"
     M15 = "15m"
     H1  = "1h"
     H4  = "4h"
@@ -30,22 +31,26 @@ class Signal(BaseModel):
 
     Fields
     ------
-    symbol      : Asset ticker, e.g. "ETH"
-    direction   : LONG, SHORT, or FLAT (no trade)
-    timeframe   : Candle resolution the signal was generated on
-    confidence  : Model confidence score, 0.0–1.0
-    regime      : Market regime label at signal time (e.g. "uptrend", "ranging")
-    thesis      : Plain-language explanation of why this signal was generated
-    top_features: Optional list of (feature_name, importance) pairs from the model
+    symbol               : Asset ticker, e.g. "ETH"
+    direction            : LONG, SHORT, or FLAT (no trade)
+    timeframe            : Candle resolution the signal was generated on
+    confidence           : Model confidence score, 0.0–1.0
+    regime               : Market regime label at signal time
+    thesis               : Plain-language explanation of why this signal was generated
+    top_features         : Optional list of (feature_name, importance) pairs from the model
+    confluence           : "full" (3+ TFs agree) | "partial" (2 TFs agree) | None
+    confluence_timeframes: Timeframes that agreed on the same direction
     """
 
-    symbol:       str               = Field(..., examples=["ETH"])
-    direction:    Direction         = Field(..., examples=[Direction.LONG])
-    timeframe:    Timeframe         = Field(Timeframe.M15)
-    confidence:   float             = Field(..., ge=0.0, le=1.0, examples=[0.72])
-    regime:       str               = Field(..., examples=["uptrend"])
-    thesis:       str               = Field(..., examples=["RSI reset from oversold, OI expanding, L/S ratio turning bullish."])
-    top_features: Optional[list[tuple[str, float]]] = Field(None)
+    symbol:                str               = Field(..., examples=["ETH"])
+    direction:             Direction         = Field(..., examples=[Direction.LONG])
+    timeframe:             Timeframe         = Field(Timeframe.M15)
+    confidence:            float             = Field(..., ge=0.0, le=1.0, examples=[0.72])
+    regime:                str               = Field(..., examples=["uptrend"])
+    thesis:                str               = Field(..., examples=["RSI reset from oversold, OI expanding, L/S ratio turning bullish."])
+    top_features:          Optional[list[tuple[str, float]]] = Field(None)
+    confluence:            Optional[str]     = Field(None)
+    confluence_timeframes: Optional[list[str]] = Field(None)
 
     class Config:
         use_enum_values = True

--- a/app/providers/file_provider.py
+++ b/app/providers/file_provider.py
@@ -1,0 +1,56 @@
+"""File-based signal provider — loads signals from SIGNAL_FILE_PATH."""
+
+import json
+import logging
+
+from app.core.config import settings
+from app.repositories.signal_repository import (
+    SignalSnapshot,
+    _error_snapshot,
+    _parse_snapshot,
+)
+
+log = logging.getLogger(__name__)
+
+_SOURCE = "file"
+
+
+def get_signals() -> SignalSnapshot:
+    """Load and validate signals from the file at settings.signal_file_path."""
+    path = settings.signal_file_path
+    if not path:
+        log.warning("event=provider_load provider=file error=path_not_set")
+        return _error_snapshot(_SOURCE, "SIGNAL_FILE_PATH is not configured")
+
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except FileNotFoundError:
+        log.warning("event=provider_load provider=file error=file_not_found path=%s", path)
+        return _error_snapshot(_SOURCE, f"Signal file not found: {path}")
+    except json.JSONDecodeError as exc:
+        log.warning("event=provider_load provider=file error=invalid_json path=%s exc=%s", path, exc)
+        return _error_snapshot(_SOURCE, "Invalid JSON in signal file")
+    except OSError as exc:
+        log.warning("event=provider_load provider=file error=io_error path=%s exc=%s", path, exc)
+        return _error_snapshot(_SOURCE, f"I/O error: {exc}")
+
+    try:
+        snapshot = _parse_snapshot(raw, _SOURCE)
+    except ValueError as exc:
+        log.warning("event=provider_load provider=file error=malformed_payload exc=%s", exc)
+        return _error_snapshot(_SOURCE, f"Malformed snapshot: {exc}")
+
+    if not snapshot.signals:
+        log.info("event=provider_load provider=file status=empty path=%s", path)
+        from dataclasses import replace
+        return replace(snapshot, status="empty")
+
+    log.info(
+        "event=provider_load provider=file status=ok signal_count=%d "
+        "model=%s generated_at=%s",
+        len(snapshot.signals),
+        snapshot.model_version or "unknown",
+        snapshot.generated_at or "unknown",
+    )
+    return snapshot

--- a/app/providers/local_provider.py
+++ b/app/providers/local_provider.py
@@ -1,0 +1,61 @@
+"""Local-snapshot signal provider — reads data/signals_snapshot.json."""
+
+import json
+import logging
+from pathlib import Path
+
+from app.repositories.signal_repository import (
+    SignalSnapshot,
+    _error_snapshot,
+    _parse_snapshot,
+)
+
+log = logging.getLogger(__name__)
+
+_SNAPSHOT_PATH = Path(__file__).resolve().parents[2] / "data" / "signals_snapshot.json"
+_SOURCE = "local_snapshot"
+
+
+def get_signals() -> SignalSnapshot:
+    """Load and validate signals from the local snapshot file."""
+    try:
+        with open(_SNAPSHOT_PATH, encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except FileNotFoundError:
+        log.warning(
+            "event=provider_load provider=local error=file_not_found path=%s",
+            _SNAPSHOT_PATH,
+        )
+        return _error_snapshot(_SOURCE, "Snapshot file not found")
+    except json.JSONDecodeError as exc:
+        log.warning(
+            "event=provider_load provider=local error=invalid_json exc=%s", exc
+        )
+        return _error_snapshot(_SOURCE, "Invalid JSON in snapshot file")
+    except OSError as exc:
+        log.warning(
+            "event=provider_load provider=local error=io_error exc=%s", exc
+        )
+        return _error_snapshot(_SOURCE, f"I/O error: {exc}")
+
+    try:
+        snapshot = _parse_snapshot(raw, _SOURCE)
+    except ValueError as exc:
+        log.warning(
+            "event=provider_load provider=local error=malformed_payload exc=%s", exc
+        )
+        return _error_snapshot(_SOURCE, f"Malformed snapshot: {exc}")
+
+    if not snapshot.signals:
+        log.info("event=provider_load provider=local status=empty")
+        from dataclasses import replace
+        return replace(snapshot, status="empty")
+
+    log.info(
+        "event=provider_load provider=local status=ok signal_count=%d "
+        "model=%s generated_at=%s",
+        len(snapshot.signals),
+        snapshot.model_version or "unknown",
+        snapshot.generated_at or "unknown",
+    )
+    return snapshot

--- a/app/providers/mock_provider.py
+++ b/app/providers/mock_provider.py
@@ -1,0 +1,148 @@
+"""Mock signal provider — returns hardcoded signals with no I/O."""
+
+import logging
+
+from app.domain.signals import Direction, Signal, Timeframe
+from app.repositories.signal_repository import SignalSnapshot
+
+log = logging.getLogger(__name__)
+
+
+def get_signals() -> SignalSnapshot:
+    """Return a snapshot of hardcoded mock signals as the primary source."""
+    signals = _build_signals()
+    log.info(
+        "event=provider_load provider=mock signal_count=%d",
+        len(signals),
+    )
+    return SignalSnapshot(
+        signals=signals,
+        source="mock",
+        used_mock_fallback=False,
+        status="ok",
+    )
+
+
+def _build_signals() -> list[Signal]:
+    return [
+        Signal(
+            symbol="ETH",
+            direction=Direction.LONG,
+            timeframe=Timeframe.M15,
+            confidence=0.74,
+            regime="uptrend",
+            thesis=(
+                "RSI 14 recovered above 48 after a clean pullback to the 20-EMA. "
+                "Open interest expanding while funding rate stays neutral. "
+                "L/S ratio at 1.42 — spot buyers absorbing futures pressure."
+            ),
+            top_features=[
+                ("rsi_14", 0.18),
+                ("oi_change_1h", 0.15),
+                ("ls_ratio", 0.13),
+                ("ema_20_dist", 0.11),
+            ],
+        ),
+        Signal(
+            symbol="SOL",
+            direction=Direction.LONG,
+            timeframe=Timeframe.H1,
+            confidence=0.68,
+            regime="uptrend",
+            thesis=(
+                "Higher-lows structure intact on the 1h. MACD crossed bullish above signal line. "
+                "Funding rate neutral — no crowded longs to unwind. "
+                "Top-trader L/S at 1.28, slightly elevated but not extreme."
+            ),
+            top_features=[
+                ("macd_hist", 0.21),
+                ("higher_lows_count", 0.16),
+                ("funding_rate", 0.12),
+                ("top_trader_ls", 0.10),
+            ],
+        ),
+        Signal(
+            symbol="INJ",
+            direction=Direction.LONG,
+            timeframe=Timeframe.M15,
+            confidence=0.77,
+            regime="uptrend",
+            thesis=(
+                "Three consecutive 15m closes above the 20-EMA with increasing volume. "
+                "Top-trader long/short flipped bullish in the last 2h. "
+                "RSI at 59 — momentum present, not yet overbought."
+            ),
+            top_features=[
+                ("consec_closes_above_ema", 0.22),
+                ("top_trader_ls", 0.19),
+                ("rsi_14", 0.14),
+                ("volume_ratio", 0.11),
+            ],
+        ),
+        Signal(
+            symbol="AVAX",
+            direction=Direction.LONG,
+            timeframe=Timeframe.M15,
+            confidence=0.71,
+            regime="uptrend",
+            thesis=(
+                "Broke above 4h resistance with volume confirmation on the 15m. "
+                "Exchange netflow negative — withdrawals outpacing deposits, "
+                "consistent with accumulation rather than distribution."
+            ),
+            top_features=[
+                ("breakout_4h_res", 0.20),
+                ("exchange_netflow_1h", 0.17),
+                ("volume_ratio", 0.13),
+            ],
+        ),
+        Signal(
+            symbol="DOGE",
+            direction=Direction.SHORT,
+            timeframe=Timeframe.M15,
+            confidence=0.63,
+            regime="downtrend",
+            thesis=(
+                "Failed to reclaim the 50-EMA on three attempts — each bounce weaker than the last. "
+                "Volume declining on bounces, elevated on drops. "
+                "OI flat while price drifts lower: not a squeeze setup, just distribution."
+            ),
+            top_features=[
+                ("ema_50_rejection_count", 0.19),
+                ("volume_on_bounce", 0.15),
+                ("oi_trend", 0.12),
+            ],
+        ),
+        Signal(
+            symbol="BTC",
+            direction=Direction.FLAT,
+            timeframe=Timeframe.M15,
+            confidence=0.51,
+            regime="ranging",
+            thesis=(
+                "Price consolidating in a 1.3% band for 8 hours. "
+                "ATR contracting, Bollinger Bands squeezing. "
+                "No directional edge — model returning FLAT to avoid chop."
+            ),
+            top_features=[
+                ("atr_14", 0.24),
+                ("bb_width", 0.18),
+                ("adx_14", 0.16),
+            ],
+        ),
+        Signal(
+            symbol="LINK",
+            direction=Direction.FLAT,
+            timeframe=Timeframe.H1,
+            confidence=0.46,
+            regime="ranging",
+            thesis=(
+                "Regime unclear — oscillating between EMA clusters on the 1h with no follow-through. "
+                "Confidence below the 0.55 threshold. No trade."
+            ),
+            top_features=[
+                ("regime_score", 0.27),
+                ("ema_cluster_dist", 0.19),
+            ],
+        ),
+    ]

--- a/app/providers/sentinel_provider.py
+++ b/app/providers/sentinel_provider.py
@@ -1,0 +1,102 @@
+"""Sentinel SSH signal provider — fetches snapshot from remote host via SSH."""
+
+import json
+import logging
+import subprocess
+
+from app.core.config import settings
+from app.repositories.signal_repository import (
+    SignalSnapshot,
+    _error_snapshot,
+    _parse_snapshot,
+)
+
+log = logging.getLogger(__name__)
+
+_SOURCE = "sentinel_ssh"
+
+
+def get_signals() -> SignalSnapshot:
+    """Fetch and validate signals from Sentinel via SSH."""
+    if not settings.sentinel_ssh_host:
+        log.warning("event=provider_load provider=sentinel error=host_not_configured")
+        return _error_snapshot(_SOURCE, "SENTINEL_SSH_HOST is not configured")
+
+    strict = "yes" if settings.sentinel_ssh_strict_host_key_checking else "no"
+    timeout = settings.sentinel_ssh_timeout_seconds
+
+    cmd = ["ssh"]
+    if settings.sentinel_ssh_key_path:
+        cmd += ["-i", settings.sentinel_ssh_key_path]
+    cmd += [
+        "-o", f"StrictHostKeyChecking={strict}",
+        "-o", f"ConnectTimeout={timeout}",
+        f"{settings.sentinel_ssh_user}@{settings.sentinel_ssh_host}",
+        settings.sentinel_snapshot_command,
+    ]
+
+    log.debug(
+        "event=provider_load provider=sentinel action=ssh_connect "
+        "host=%s user=%s timeout=%ds",
+        settings.sentinel_ssh_host,
+        settings.sentinel_ssh_user,
+        timeout,
+    )
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout + 2
+        )
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "event=provider_load provider=sentinel error=timeout timeout_s=%d host=%s",
+            timeout,
+            settings.sentinel_ssh_host,
+        )
+        return _error_snapshot(_SOURCE, f"SSH timeout after {timeout}s")
+
+    if result.returncode != 0:
+        stderr_preview = result.stderr.strip()[:200]
+        log.warning(
+            "event=provider_load provider=sentinel error=nonzero_exit "
+            "returncode=%d stderr=%s",
+            result.returncode,
+            stderr_preview or "(none)",
+        )
+        return _error_snapshot(
+            _SOURCE, f"SSH exited {result.returncode}: {stderr_preview or '(no stderr)'}"
+        )
+
+    if not result.stdout.strip():
+        log.warning("event=provider_load provider=sentinel error=empty_stdout")
+        return _error_snapshot(_SOURCE, "SSH succeeded but stdout was empty")
+
+    try:
+        raw = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        log.warning(
+            "event=provider_load provider=sentinel error=invalid_json exc=%s", exc
+        )
+        return _error_snapshot(_SOURCE, "Invalid JSON from Sentinel")
+
+    try:
+        snapshot = _parse_snapshot(raw, _SOURCE)
+    except ValueError as exc:
+        log.warning(
+            "event=provider_load provider=sentinel error=malformed_payload exc=%s", exc
+        )
+        return _error_snapshot(_SOURCE, f"Malformed snapshot: {exc}")
+
+    if not snapshot.signals:
+        log.info("event=provider_load provider=sentinel status=empty")
+        from dataclasses import replace
+        return replace(snapshot, status="empty")
+
+    log.info(
+        "event=provider_load provider=sentinel status=ok signal_count=%d "
+        "model=%s generated_at=%s",
+        len(snapshot.signals),
+        snapshot.model_version or "unknown",
+        snapshot.generated_at or "unknown",
+    )
+    return snapshot

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
@@ -6,6 +8,7 @@ from pathlib import Path
 from app.core.config import settings
 
 router = APIRouter()
+log = logging.getLogger(__name__)
 
 templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "templates")
 
@@ -28,6 +31,12 @@ async def health():
     Returns service identity, version, environment, and a lightweight
     summary of the signal source configuration.
     """
+    log.info(
+        "event=health_check version=%s environment=%s provider=%s",
+        settings.app_version,
+        settings.environment,
+        settings.signal_provider,
+    )
     return {
         "status":      "ok",
         "service":     settings.app_name,
@@ -51,6 +60,11 @@ async def health_signals():
     Useful for diagnosing which source is active, whether Sentinel is
     configured, and what timeout is in use.  Does not perform a live probe.
     """
+    log.info(
+        "event=health_signals_check provider=%s sentinel_configured=%s",
+        settings.signal_provider,
+        settings.sentinel_configured,
+    )
     sentinel_info: dict = {
         "configured": settings.sentinel_configured,
     }

--- a/app/routes/signals.py
+++ b/app/routes/signals.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -7,6 +9,7 @@ from app.core.config import settings
 from app.services.signal_service import get_signals
 
 router = APIRouter()
+log = logging.getLogger(__name__)
 
 templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "templates")
 
@@ -15,6 +18,16 @@ templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "tem
 async def signal_feed(request: Request):
     snapshot = get_signals()
     signals  = snapshot.signals
+    log.info(
+        "event=signal_feed_render signal_count=%d source=%s status=%s "
+        "used_mock_fallback=%s generated_at=%s model_version=%s",
+        len(signals),
+        snapshot.source,
+        snapshot.status,
+        snapshot.used_mock_fallback,
+        snapshot.generated_at or "unknown",
+        snapshot.model_version or "unknown",
+    )
 
     # Format generated_at for display ("2026-04-22T12:00:00Z" → "2026-04-22 12:00 UTC")
     generated_at_display: str | None = None

--- a/app/services/confluence_engine.py
+++ b/app/services/confluence_engine.py
@@ -1,0 +1,127 @@
+"""
+Multi-Timeframe Signal Confluence Engine.
+
+Groups signals by symbol across timeframes (5m, 15m, 1h) and marks each
+signal with its confluence level:
+
+  "full"    — 3 or more timeframes agree on the same non-FLAT direction
+  "partial" — exactly 2 timeframes agree
+  None      — no confluence (single timeframe or all disagree)
+
+Confidence is boosted for confluent signals so they sort higher on the feed:
+  full    → +0.10  (capped at 0.95)
+  partial → +0.05  (capped at 0.90)
+
+The primary signal for each symbol (highest raw confidence among agreeing TFs)
+is returned; its confluence_timeframes field lists the TFs that agreed.
+Non-confluent symbols are returned unchanged with confluence=None.
+"""
+
+import logging
+from collections import defaultdict
+from app.domain.signals import Direction, Signal
+
+log = logging.getLogger(__name__)
+
+_CONFLUENCE_TFS = {"5m", "15m", "1h"}
+
+
+def evaluate_confluence(signals: list[Signal]) -> list[Signal]:
+    """
+    Mark each signal with its confluence level and boost confidence.
+
+    Signals for symbols that appear on only one timeframe pass through
+    untouched. Signals outside the confluence timeframe set (e.g. 4h) pass
+    through untouched.
+
+    Returns a deduplicated list: one signal per symbol (the highest-confidence
+    agreeing signal when confluent, the original signal otherwise).
+    """
+    by_symbol: dict[str, list[Signal]] = defaultdict(list)
+    pass_through: list[Signal] = []
+
+    for sig in signals:
+        if sig.timeframe in _CONFLUENCE_TFS:
+            by_symbol[sig.symbol].append(sig)
+        else:
+            pass_through.append(sig)
+
+    result: list[Signal] = list(pass_through)
+
+    for symbol, sym_sigs in by_symbol.items():
+        elevated = _elevate(sym_sigs)
+        result.extend(elevated)
+
+    log.info(
+        "event=confluence_evaluated symbol_count=%d elevated=%d pass_through=%d",
+        len(by_symbol),
+        len(result) - len(pass_through),
+        len(pass_through),
+    )
+    return result
+
+
+def filter_confluent(signals: list[Signal]) -> list[Signal]:
+    """Return only signals that have a confluence tag (full or partial)."""
+    return [s for s in signals if s.confluence is not None]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _elevate(sym_sigs: list[Signal]) -> list[Signal]:
+    """
+    Determine confluence for a group of same-symbol signals and return the
+    elevated primary signal(s).
+
+    Returns a list because non-confluent symbols keep all their signals,
+    while confluent ones are collapsed to the single best signal.
+    """
+    if len(sym_sigs) == 1:
+        return sym_sigs
+
+    # Count agreement on non-FLAT directions only
+    direction_groups: dict[str, list[Signal]] = defaultdict(list)
+    for sig in sym_sigs:
+        if sig.direction != Direction.FLAT:
+            direction_groups[sig.direction].append(sig)
+
+    if not direction_groups:
+        # All FLAT — no confluence possible
+        return sym_sigs
+
+    best_direction = max(direction_groups, key=lambda d: len(direction_groups[d]))
+    agreeing = direction_groups[best_direction]
+    count = len(agreeing)
+
+    if count >= 3:
+        level, boost, cap = "full", 0.10, 0.95
+    elif count == 2:
+        level, boost, cap = "partial", 0.05, 0.90
+    else:
+        # Only one timeframe has this direction — no confluence
+        return sym_sigs
+
+    # Primary = highest raw confidence among agreeing signals
+    primary = max(agreeing, key=lambda s: s.confidence)
+    boosted = min(round(primary.confidence + boost, 2), cap)
+    agreeing_tfs = sorted(s.timeframe for s in agreeing)
+
+    elevated = primary.model_copy(update={
+        "confidence": boosted,
+        "confluence": level,
+        "confluence_timeframes": agreeing_tfs,
+    })
+
+    log.debug(
+        "event=signal_elevated symbol=%s direction=%s confluence=%s "
+        "timeframes=%s confidence_raw=%.2f confidence_boosted=%.2f",
+        primary.symbol,
+        best_direction,
+        level,
+        agreeing_tfs,
+        primary.confidence,
+        boosted,
+    )
+    return [elevated]

--- a/app/services/digest_generator.py
+++ b/app/services/digest_generator.py
@@ -1,0 +1,303 @@
+"""
+Daily Signal Digest Generator.
+
+Produces three publish-ready artifacts from a snapshot of signals:
+
+  1. market_summary   — overall market tone (bullish / bearish / mixed / neutral)
+                        with signal counts and average confidence
+  2. strongest_setups — top-N signals ranked by confidence, each with a
+                        one-line headline and the full structured thesis
+  3. digest_content   — a markdown-formatted blog/email body ready to publish
+
+All output is deterministic for a given snapshot so the same signals always
+produce the same digest.
+"""
+
+import hashlib
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.domain.signals import Direction, Signal
+from app.services.thesis_generator import SignalThesis, generate_thesis
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SetupSummary:
+    signal: Signal
+    headline: str
+    thesis: SignalThesis
+
+
+@dataclass
+class MarketSummary:
+    tone: str                 # "bullish" | "bearish" | "mixed" | "neutral"
+    long_count: int
+    short_count: int
+    flat_count: int
+    total: int
+    avg_confidence: float
+    top_regime: str
+    summary_line: str
+
+
+@dataclass
+class SignalDigest:
+    generated_at: str
+    market_summary: MarketSummary
+    strongest_setups: list[SetupSummary]
+    digest_content: str       # publish-ready markdown
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def generate_digest(signals: list[Signal], top_n: int = 5) -> SignalDigest:
+    """
+    Build a full daily digest from the provided signal list.
+
+    Parameters
+    ----------
+    signals : list of Signal objects (from any provider)
+    top_n   : number of top setups to feature (default: 5)
+
+    Returns
+    -------
+    SignalDigest with market_summary, strongest_setups, and digest_content.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    market = _build_market_summary(signals)
+    setups = _build_strongest_setups(signals, top_n)
+    content = _render_digest(market, setups, now)
+
+    return SignalDigest(
+        generated_at=now,
+        market_summary=market,
+        strongest_setups=setups,
+        digest_content=content,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Market summary
+# ---------------------------------------------------------------------------
+
+def _build_market_summary(signals: list[Signal]) -> MarketSummary:
+    if not signals:
+        return MarketSummary(
+            tone="neutral",
+            long_count=0,
+            short_count=0,
+            flat_count=0,
+            total=0,
+            avg_confidence=0.0,
+            top_regime="unknown",
+            summary_line="No signals available for today's digest.",
+        )
+
+    long_sigs  = [s for s in signals if s.direction == Direction.LONG]
+    short_sigs = [s for s in signals if s.direction == Direction.SHORT]
+    flat_sigs  = [s for s in signals if s.direction == Direction.FLAT]
+
+    long_count  = len(long_sigs)
+    short_count = len(short_sigs)
+    flat_count  = len(flat_sigs)
+    total       = len(signals)
+
+    avg_conf = round(sum(s.confidence for s in signals) / total, 2)
+
+    # Most common regime
+    regime_counts: dict[str, int] = {}
+    for s in signals:
+        regime_counts[s.regime] = regime_counts.get(s.regime, 0) + 1
+    top_regime = max(regime_counts, key=lambda r: regime_counts[r])
+
+    # Market tone
+    long_pct  = long_count / total
+    short_pct = short_count / total
+    if long_pct >= 0.55:
+        tone = "bullish"
+    elif short_pct >= 0.55:
+        tone = "bearish"
+    elif abs(long_pct - short_pct) <= 0.10:
+        tone = "mixed"
+    else:
+        tone = "neutral"
+
+    summary_line = _tone_summary(tone, long_count, short_count, flat_count, avg_conf, top_regime)
+
+    return MarketSummary(
+        tone=tone,
+        long_count=long_count,
+        short_count=short_count,
+        flat_count=flat_count,
+        total=total,
+        avg_confidence=avg_conf,
+        top_regime=top_regime,
+        summary_line=summary_line,
+    )
+
+
+_TONE_LINES: dict[str, list[str]] = {
+    "bullish": [
+        "The model is leaning strongly long today with {longs} buy setups against {shorts} shorts. "
+        "Dominant regime: {regime}. Average confidence sits at {conf}% — above the action threshold.",
+
+        "{longs} of {total} signals are long-biased in a {regime} environment. "
+        "Today's session favours trend-following long exposure over counter-trend plays.",
+    ],
+    "bearish": [
+        "Bearish bias dominates with {shorts} short setups and only {longs} on the long side. "
+        "Regime: {regime}. Model confidence averaging {conf}% — proceed with defined risk.",
+
+        "The model is leaning short: {shorts} signals flagged for downside against {longs} longs. "
+        "In a {regime} environment, the path of least resistance is lower.",
+    ],
+    "mixed": [
+        "Today's signals are split — {longs} long, {shorts} short, {flats} flat — in a {regime} market. "
+        "No strong directional edge. Selective, high-confidence setups only.",
+
+        "Mixed read: equal weighting across directions with a {regime} backdrop. "
+        "Average confidence {conf}%. Focus on the highest-conviction setups only.",
+    ],
+    "neutral": [
+        "{flats} of {total} signals are FLAT with {longs} long and {shorts} short. "
+        "The model sees limited edge in current conditions. Patience is a position.",
+
+        "Regime unclear. {flats} FLAT signals, {longs} long, {shorts} short. "
+        "Average confidence {conf}%. Waiting for clearer structure before deploying size.",
+    ],
+}
+
+
+def _tone_summary(
+    tone: str,
+    longs: int,
+    shorts: int,
+    flats: int,
+    conf: float,
+    regime: str,
+) -> str:
+    total = longs + shorts + flats
+    templates = _TONE_LINES[tone]
+    # Deterministic selection from tone + counts
+    key = f"{tone}:{longs}:{shorts}:{flats}"
+    idx = int(hashlib.sha256(key.encode()).hexdigest(), 16) % len(templates)
+    return templates[idx].format(
+        longs=longs,
+        shorts=shorts,
+        flats=flats,
+        total=total,
+        conf=int(round(conf * 100)),
+        regime=regime,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strongest setups
+# ---------------------------------------------------------------------------
+
+def _build_strongest_setups(signals: list[Signal], top_n: int) -> list[SetupSummary]:
+    # Only directional (non-FLAT) signals qualify as "setups"
+    directional = [s for s in signals if s.direction != Direction.FLAT]
+    directional.sort(key=lambda s: s.confidence, reverse=True)
+    top = directional[:top_n]
+
+    return [
+        SetupSummary(
+            signal=sig,
+            headline=_headline(sig),
+            thesis=generate_thesis(sig),
+        )
+        for sig in top
+    ]
+
+
+_HEADLINE_LONG = [
+    "{symbol} ({tf}) — LONG at {conf}% confidence | {regime}",
+    "Buy setup: {symbol} {tf} — {conf}% model conviction | {regime} regime",
+    "{symbol} long signal on the {tf} | confidence {conf}% | {regime}",
+]
+_HEADLINE_SHORT = [
+    "{symbol} ({tf}) — SHORT at {conf}% confidence | {regime}",
+    "Short setup: {symbol} {tf} — {conf}% model conviction | {regime} regime",
+    "{symbol} short signal on the {tf} | confidence {conf}% | {regime}",
+]
+
+
+def _headline(sig: Signal) -> str:
+    key = f"{sig.symbol}:{sig.direction}:{sig.timeframe}"
+    seed = int(hashlib.sha256(key.encode()).hexdigest(), 16) % (2 ** 32)
+    rng = random.Random(seed)
+    pool = _HEADLINE_LONG if sig.direction == Direction.LONG else _HEADLINE_SHORT
+    template = rng.choice(pool)
+    return template.format(
+        symbol=sig.symbol,
+        tf=sig.timeframe,
+        conf=int(round(sig.confidence * 100)),
+        regime=sig.regime,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Digest rendering (markdown)
+# ---------------------------------------------------------------------------
+
+def _render_digest(
+    market: MarketSummary,
+    setups: list[SetupSummary],
+    generated_at: str,
+) -> str:
+    date_str = generated_at[:10]  # "YYYY-MM-DD"
+    lines: list[str] = [
+        f"# AlphaForge Signal Digest — {date_str}",
+        "",
+        "## Market Overview",
+        "",
+        f"**Tone:** {market.tone.upper()}  ",
+        f"**Signals:** {market.long_count} long · {market.short_count} short · {market.flat_count} flat  ",
+        f"**Avg Confidence:** {int(round(market.avg_confidence * 100))}%  ",
+        f"**Dominant Regime:** {market.top_regime}  ",
+        "",
+        market.summary_line,
+        "",
+        "---",
+        "",
+        "## Strongest Setups",
+        "",
+    ]
+
+    if not setups:
+        lines.append("*No directional setups meet the confidence threshold today.*")
+    else:
+        for i, setup in enumerate(setups, start=1):
+            sig = setup.signal
+            t = setup.thesis
+            lines += [
+                f"### {i}. {setup.headline}",
+                "",
+                f"**Setup Rationale:** {t.setup_rationale}",
+                "",
+                f"**Invalidation:** {t.invalidation}",
+                "",
+                f"**Risk:** {t.risk_thesis}",
+                "",
+                f"**Catalyst Watch:** {t.catalyst_notes}",
+                "",
+            ]
+
+    lines += [
+        "---",
+        "",
+        f"*Generated by AlphaForgeAI — {generated_at} — model: synthetic-v1*",
+        "*Not financial advice. For research and entertainment purposes only.*",
+    ]
+
+    return "\n".join(lines)

--- a/app/services/signal_service.py
+++ b/app/services/signal_service.py
@@ -1,88 +1,60 @@
 """
-Signal service layer.
+Signal service — provider dispatcher and mock-fallback logic.
 
-Calls the repository and decides whether to fall back to hardcoded mocks.
-Returns a SignalSnapshot that the route unpacks into template context.
+Selects the configured provider, delegates to it, and applies the
+mock-fallback policy when the provider returns no signals.
 
-Fallback policy
----------------
-Mock fallback is controlled by ``settings.allow_mock_fallback``:
+Provider selection (SIGNAL_PROVIDER env var)
+--------------------------------------------
+"mock"         → app.providers.mock_provider   (no I/O)
+"file"         → app.providers.file_provider   (SIGNAL_FILE_PATH)
+"sentinel_ssh" → app.providers.sentinel_provider (SSH)
+other / unset  → app.providers.local_provider  (data/signals_snapshot.json)
 
-- development (default) → True   — UI is never blank during local work
-- production  (default) → False  — empty snapshot surfaces as empty feed;
-                                    no silent data injection
-
-Override at runtime with the ALLOW_MOCK_FALLBACK env var.
-
-Swap guide (live source)
--------------------------
-Point at a different repository by changing this import:
-
-    from app.repositories.sentinel_repository import get_signals as _repo_get_signals
-
-The rest of this file — fallback logic, return type, mock data — is unchanged.
+Fallback policy (ALLOW_MOCK_FALLBACK env var)
+----------------------------------------------
+development (default) → True   — UI is never blank during local work
+production  (default) → False  — empty snapshot surfaces as empty feed
 """
 
 import logging
 from dataclasses import replace
 
 from app.core.config import settings
-from app.domain.signals import Direction, Signal, Timeframe
+from app.domain.signals import Signal
 from app.repositories.signal_repository import SignalSnapshot
-from app.repositories.signal_repository import (
-    get_signals as _repo_get_signals,
-    get_signals_from_file as _repo_get_signals_from_file,
-)
 
 log = logging.getLogger(__name__)
 
 
 def get_signals() -> SignalSnapshot:
-    """
-    Return a SignalSnapshot from the configured provider.
+    """Dispatch to the configured provider and apply fallback if needed."""
+    from app.providers import (
+        file_provider,
+        local_provider,
+        mock_provider,
+        sentinel_provider,
+    )
 
-    Provider selection (SIGNAL_PROVIDER env var):
-      "mock" — hardcoded mock signals served directly as the primary source.
-      "file" — signals loaded from SIGNAL_FILE_PATH; falls back to mocks if
-               the file is missing/invalid and allow_mock_fallback is True.
-      other  — legacy SIGNAL_SOURCE path (local_snapshot / sentinel_ssh).
-
-    If any provider returns no signals and ``settings.allow_mock_fallback``
-    is True the response is replaced with hardcoded mocks.
-    """
     provider = settings.signal_provider
 
-    # ── Mock provider: serve mocks directly (no file I/O) ───────────────────
-    if provider == "mock":
-        log.info(
-            "signal_provider=mock — serving mock signals as primary source "
-            "(environment=%s)",
-            settings.environment,
-        )
-        return SignalSnapshot(
-            signals=get_mock_signals(),
-            source="mock",
-            used_mock_fallback=False,
-            status="ok",
-        )
+    _PROVIDERS = {
+        "mock":         mock_provider.get_signals,
+        "file":         file_provider.get_signals,
+        "sentinel_ssh": sentinel_provider.get_signals,
+    }
 
-    # ── File provider: load from SIGNAL_FILE_PATH ────────────────────────────
-    if provider == "file":
-        snapshot = _repo_get_signals_from_file()
-    else:
-        # Legacy: local_snapshot / sentinel_ssh via SIGNAL_SOURCE
-        snapshot = _repo_get_signals()
+    load = _PROVIDERS.get(provider, local_provider.get_signals)
+    snapshot = load()
 
     if not snapshot.signals:
         if settings.allow_mock_fallback:
             log.info(
-                "Repository returned no signals (status=%s) — using mock fallback "
-                "(allow_mock_fallback=True, environment=%s)",
+                "event=mock_fallback_activated provider=%s status=%s environment=%s",
+                provider,
                 snapshot.status,
                 settings.environment,
             )
-            # Preserve error_message from the original snapshot so the UI can
-            # show both "mock fallback active" and the original failure reason.
             return replace(
                 snapshot,
                 signals=get_mock_signals(),
@@ -91,8 +63,8 @@ def get_signals() -> SignalSnapshot:
                 status="fallback",
             )
         log.info(
-            "Repository returned no signals (status=%s) — returning empty feed "
-            "(allow_mock_fallback=False, environment=%s)",
+            "event=empty_feed_returned provider=%s status=%s environment=%s",
+            provider,
             snapshot.status,
             settings.environment,
         )
@@ -100,136 +72,7 @@ def get_signals() -> SignalSnapshot:
     return snapshot
 
 
-# ---------------------------------------------------------------------------
-# Mock signals — fallback only, not the primary source
-# ---------------------------------------------------------------------------
-
 def get_mock_signals() -> list[Signal]:
-    """
-    Hardcoded mock signals used only as a fallback when the snapshot is
-    empty or unavailable and allow_mock_fallback is True.
-
-    Values reflect plausible model output, not live market data.
-    """
-    return [
-        Signal(
-            symbol="ETH",
-            direction=Direction.LONG,
-            timeframe=Timeframe.M15,
-            confidence=0.74,
-            regime="uptrend",
-            thesis=(
-                "RSI 14 recovered above 48 after a clean pullback to the 20-EMA. "
-                "Open interest expanding while funding rate stays neutral. "
-                "L/S ratio at 1.42 — spot buyers absorbing futures pressure."
-            ),
-            top_features=[
-                ("rsi_14", 0.18),
-                ("oi_change_1h", 0.15),
-                ("ls_ratio", 0.13),
-                ("ema_20_dist", 0.11),
-            ],
-        ),
-        Signal(
-            symbol="SOL",
-            direction=Direction.LONG,
-            timeframe=Timeframe.H1,
-            confidence=0.68,
-            regime="uptrend",
-            thesis=(
-                "Higher-lows structure intact on the 1h. MACD crossed bullish above signal line. "
-                "Funding rate neutral — no crowded longs to unwind. "
-                "Top-trader L/S at 1.28, slightly elevated but not extreme."
-            ),
-            top_features=[
-                ("macd_hist", 0.21),
-                ("higher_lows_count", 0.16),
-                ("funding_rate", 0.12),
-                ("top_trader_ls", 0.10),
-            ],
-        ),
-        Signal(
-            symbol="INJ",
-            direction=Direction.LONG,
-            timeframe=Timeframe.M15,
-            confidence=0.77,
-            regime="uptrend",
-            thesis=(
-                "Three consecutive 15m closes above the 20-EMA with increasing volume. "
-                "Top-trader long/short flipped bullish in the last 2h. "
-                "RSI at 59 — momentum present, not yet overbought."
-            ),
-            top_features=[
-                ("consec_closes_above_ema", 0.22),
-                ("top_trader_ls", 0.19),
-                ("rsi_14", 0.14),
-                ("volume_ratio", 0.11),
-            ],
-        ),
-        Signal(
-            symbol="AVAX",
-            direction=Direction.LONG,
-            timeframe=Timeframe.M15,
-            confidence=0.71,
-            regime="uptrend",
-            thesis=(
-                "Broke above 4h resistance with volume confirmation on the 15m. "
-                "Exchange netflow negative — withdrawals outpacing deposits, "
-                "consistent with accumulation rather than distribution."
-            ),
-            top_features=[
-                ("breakout_4h_res", 0.20),
-                ("exchange_netflow_1h", 0.17),
-                ("volume_ratio", 0.13),
-            ],
-        ),
-        Signal(
-            symbol="DOGE",
-            direction=Direction.SHORT,
-            timeframe=Timeframe.M15,
-            confidence=0.63,
-            regime="downtrend",
-            thesis=(
-                "Failed to reclaim the 50-EMA on three attempts — each bounce weaker than the last. "
-                "Volume declining on bounces, elevated on drops. "
-                "OI flat while price drifts lower: not a squeeze setup, just distribution."
-            ),
-            top_features=[
-                ("ema_50_rejection_count", 0.19),
-                ("volume_on_bounce", 0.15),
-                ("oi_trend", 0.12),
-            ],
-        ),
-        Signal(
-            symbol="BTC",
-            direction=Direction.FLAT,
-            timeframe=Timeframe.M15,
-            confidence=0.51,
-            regime="ranging",
-            thesis=(
-                "Price consolidating in a 1.3% band for 8 hours. "
-                "ATR contracting, Bollinger Bands squeezing. "
-                "No directional edge — model returning FLAT to avoid chop."
-            ),
-            top_features=[
-                ("atr_14", 0.24),
-                ("bb_width", 0.18),
-                ("adx_14", 0.16),
-            ],
-        ),
-        Signal(
-            symbol="LINK",
-            direction=Direction.FLAT,
-            timeframe=Timeframe.H1,
-            confidence=0.46,
-            regime="ranging",
-            thesis=(
-                "Regime unclear — oscillating between EMA clusters on the 1h with no follow-through. "
-                "Confidence below the 0.55 threshold. No trade."
-            ),
-            top_features=[
-                ("regime_score", 0.27),
-                ("ema_cluster_dist", 0.19),
-            ],
-        ),
-    ]
+    """Return the hardcoded mock signal list (used for fallback only)."""
+    from app.providers.mock_provider import _build_signals
+    return _build_signals()

--- a/app/services/signal_service.py
+++ b/app/services/signal_service.py
@@ -55,19 +55,28 @@ def get_signals() -> SignalSnapshot:
                 snapshot.status,
                 settings.environment,
             )
-            return replace(
+            snapshot = replace(
                 snapshot,
                 signals=get_mock_signals(),
                 source="mock_fallback",
                 used_mock_fallback=True,
                 status="fallback",
             )
-        log.info(
-            "event=empty_feed_returned provider=%s status=%s environment=%s",
-            provider,
-            snapshot.status,
-            settings.environment,
-        )
+        else:
+            log.info(
+                "event=empty_feed_returned provider=%s status=%s environment=%s",
+                provider,
+                snapshot.status,
+                settings.environment,
+            )
+            return snapshot
+
+    if settings.signal_confluence:
+        from app.services.confluence_engine import evaluate_confluence, filter_confluent
+        signals = evaluate_confluence(snapshot.signals)
+        if settings.signal_confluence_filter:
+            signals = filter_confluent(signals)
+        snapshot = replace(snapshot, signals=signals)
 
     return snapshot
 

--- a/app/services/thesis_generator.py
+++ b/app/services/thesis_generator.py
@@ -1,0 +1,285 @@
+"""
+Signal Thesis Generator.
+
+For each signal, expands the single-line thesis into a structured breakdown:
+  - setup_rationale  : why the model is taking this position
+  - invalidation     : the price action that cancels the thesis
+  - risk_thesis      : tail risks and position-sizing considerations
+  - catalyst_notes   : near-term events or triggers that could accelerate
+
+Generated purely from the signal's existing fields (direction, confidence,
+regime, timeframe, top_features) — no external data required.
+
+All output is deterministic for a given signal so templates can be cached and
+the feed stays stable within a refresh window.
+"""
+
+import hashlib
+import random
+from typing import Optional
+
+from app.domain.signals import Direction, Signal
+
+
+# ---------------------------------------------------------------------------
+# Template banks
+# ---------------------------------------------------------------------------
+
+_SETUP: dict[str, list[str]] = {
+    "LONG": [
+        (
+            "Price is holding above the {tf} 20-EMA with a constructive pullback structure. "
+            "The model's top driver ({feat}) is pointing to sustained buying pressure. "
+            "Regime classified as {regime}, consistent with continuation plays."
+        ),
+        (
+            "A higher-lows sequence is intact on the {tf}. "
+            "{feat} confirms the trend has not exhausted. "
+            "Confidence at {conf}% — above the 60% threshold required for an active long setup."
+        ),
+        (
+            "Breakout structure forming: price cleared a key level with expanding volume. "
+            "{feat} is the primary driver at {feat_weight}% model weight. "
+            "Regime: {regime}. Setup favours trend continuation over reversion."
+        ),
+        (
+            "Funding rate neutral, open interest expanding — new money entering, not a short squeeze. "
+            "The {tf} candle sequence shows impulsive up-moves with corrective pullbacks. "
+            "Model confidence {conf}%; {feat} carries the most explanatory weight."
+        ),
+    ],
+    "SHORT": [
+        (
+            "Rejection at resistance is well-defined on the {tf}. "
+            "{feat} flags distribution rather than accumulation. "
+            "Regime: {regime}. Model favours lower prices while this structure holds."
+        ),
+        (
+            "A lower-highs pattern is developing. Each bounce is weaker than the last. "
+            "{feat} is the dominant bearish signal at {feat_weight}% model weight. "
+            "Confidence {conf}% — sufficient for a short bias, not a conviction trade."
+        ),
+        (
+            "Price has failed to reclaim the {tf} 50-EMA on multiple attempts. "
+            "Volume is declining on bounces and elevated on drops — textbook distribution. "
+            "{feat} confirms the bearish read. Regime: {regime}."
+        ),
+        (
+            "MACD crossed bearish; histogram expanding below zero. "
+            "Top-trader positioning flipped short in the last 2h. "
+            "{feat} leads model attribution at {feat_weight}% weight. Confidence: {conf}%."
+        ),
+    ],
+    "FLAT": [
+        (
+            "No directional edge detected on the {tf}. "
+            "{feat} shows a chop environment — ATR contracting, bands narrowing. "
+            "Model returns FLAT until regime clarifies."
+        ),
+        (
+            "Price is oscillating inside a tight range with no follow-through in either direction. "
+            "{feat} is the primary indicator of a non-trending environment. "
+            "Regime: {regime}. Sitting out until a breakout or breakdown is confirmed."
+        ),
+    ],
+}
+
+_INVALIDATION: dict[str, list[str]] = {
+    "LONG": [
+        "A {tf} close below the 20-EMA with elevated volume cancels the setup. "
+        "Secondary invalidation: RSI drops below 40 on the {tf}, signalling momentum failure.",
+
+        "Reclaim and hold above the prior swing high is the confirmation trigger. "
+        "Invalidated if price reverses back below the breakout level within 2 {tf} candles.",
+
+        "The long thesis breaks if funding turns sharply positive (crowded longs) "
+        "or if a {tf} candle closes below the key support zone with a bearish wick.",
+
+        "Invalidated on a {tf} close below the pullback low. "
+        "Stop placed just below that level; position sized to risk ≤1% of equity.",
+    ],
+    "SHORT": [
+        "A {tf} close back above the 50-EMA invalidates the bearish structure. "
+        "Secondary: if funding turns sharply negative, shorts become crowded and a squeeze risk rises.",
+
+        "Invalidated if price prints a higher high above the recent swing top on the {tf}. "
+        "That would signal the lower-highs sequence has broken.",
+
+        "The short thesis breaks on a momentum burst through resistance with volume. "
+        "Stop above the rejection level; sizing for ≤1% account risk.",
+
+        "Thesis fails if OI drops while price rallies — short covering, not real buying — "
+        "but a sustained move with expanding OI above resistance confirms invalidation.",
+    ],
+    "FLAT": [
+        "Position opens when a {tf} candle closes convincingly outside the current range "
+        "with a 1.5× ATR move and volume at least 20% above the 20-period average.",
+
+        "A range break confirmed by a second candle close outside the band; "
+        "false breakouts without follow-through volume remain inside FLAT.",
+    ],
+}
+
+_RISK: dict[str, list[str]] = {
+    "LONG": [
+        "Primary risk: macro liquidity shock (surprise rate decision, broad crypto sell-off) "
+        "overrides the technical setup. Position sizing accordingly: ≤1% account risk.",
+
+        "Leverage amplifies drawdowns if the pullback deepens before continuation. "
+        "Consider entering in two tranches — 50% at current level, 50% on confirmation close.",
+
+        "Low-confidence long (sub-70%) in a high-volatility regime can produce a quick stop-out. "
+        "Set hard stop; do not widen it reactively. Risk the plan, not the outcome.",
+
+        "Funding could spike if the move attracts retail longs — watch for a cascade stop-hunt "
+        "before the real continuation. Consider slightly wider stop to absorb the wick.",
+    ],
+    "SHORT": [
+        "Short squeeze risk is real: if OI is elevated and funding flips negative, "
+        "a catalyst could trigger rapid covering. Size to withstand a 3% adverse spike.",
+
+        "Broad market momentum can overwhelm single-asset bearish setups. "
+        "Use a correlation-adjusted position size if BTC is trending strongly upward.",
+
+        "Regime misclassification: if the model incorrectly reads {regime}, "
+        "the asset could continue higher. Hard stop required; no averaging down on shorts.",
+
+        "Event risk (listings, protocol upgrades, liquidation cascades) can gap through stops. "
+        "Avoid holding through major scheduled events without reducing size.",
+    ],
+    "FLAT": [
+        "Opportunity cost is the primary risk: missing an early breakout by waiting for confirmation. "
+        "Accept this as the cost of avoiding false breakout trades.",
+
+        "Volatility expansion risk: the range may break violently with low liquidity. "
+        "Have a clear entry plan ready on both sides before it happens.",
+    ],
+}
+
+_CATALYST: dict[str, list[str]] = {
+    "LONG": [
+        "Near-term upside catalysts: BTC strength dragging altcoins higher, "
+        "positive macro data reducing risk-off pressure, or a protocol announcement increasing utility demand.",
+
+        "Watch for a high-volume {tf} candle closing above the recent consolidation range — "
+        "that would confirm institutional participation and trigger momentum follow-through.",
+
+        "Exchange netflow turning sharply negative (large withdrawals to cold storage) "
+        "would reinforce the accumulation thesis and serve as a secondary long trigger.",
+
+        "Sentiment catalyst: if the top-trader L/S ratio continues to expand, "
+        "it signals smart-money conviction aligning with the model's LONG view.",
+    ],
+    "SHORT": [
+        "Near-term downside catalysts: BTC correlation breakdown to the downside, "
+        "broader de-risking, or negative on-chain data (exchange inflows spiking).",
+
+        "A failed retest of broken support — where the level holds as new resistance — "
+        "would validate the bearish structure and provide a lower-risk short entry.",
+
+        "Watch funding: if it turns positive despite price weakness, "
+        "leveraged longs are being trapped, accelerating the decline on any catalyst.",
+
+        "Macro: higher-than-expected CPI or Fed hawkishness tends to compress risk assets "
+        "disproportionately in the crypto space, amplifying this short thesis.",
+    ],
+    "FLAT": [
+        "A scheduled macro event (FOMC, CPI print) could be the volatility catalyst "
+        "that breaks the range definitively. Have both directional plans ready.",
+
+        "On-chain: a sudden spike in large-wallet transactions or exchange inflows "
+        "would signal institutional repositioning and may resolve the current indecision.",
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+class SignalThesis:
+    """Structured thesis for a single signal."""
+
+    def __init__(
+        self,
+        setup_rationale: str,
+        invalidation: str,
+        risk_thesis: str,
+        catalyst_notes: str,
+    ):
+        self.setup_rationale = setup_rationale
+        self.invalidation = invalidation
+        self.risk_thesis = risk_thesis
+        self.catalyst_notes = catalyst_notes
+
+    def to_dict(self) -> dict:
+        return {
+            "setup_rationale": self.setup_rationale,
+            "invalidation":    self.invalidation,
+            "risk_thesis":     self.risk_thesis,
+            "catalyst_notes":  self.catalyst_notes,
+        }
+
+
+def generate_thesis(signal: Signal) -> SignalThesis:
+    """
+    Generate a structured thesis for a single signal.
+
+    Output is deterministic: the same signal always produces the same thesis.
+    """
+    rng = _rng_for(signal)
+    direction = signal.direction  # already a string via use_enum_values
+
+    feat, feat_weight = _top_feature(signal)
+    conf = int(round(signal.confidence * 100))
+
+    ctx = dict(
+        tf=signal.timeframe,
+        feat=feat,
+        feat_weight=feat_weight,
+        conf=conf,
+        regime=signal.regime,
+    )
+
+    setup       = rng.choice(_SETUP[direction]).format(**ctx)
+    invalidation = rng.choice(_INVALIDATION[direction]).format(**ctx)
+    risk        = rng.choice(_RISK[direction]).format(**ctx)
+    catalyst    = rng.choice(_CATALYST[direction]).format(**ctx)
+
+    return SignalThesis(
+        setup_rationale=setup,
+        invalidation=invalidation,
+        risk_thesis=risk,
+        catalyst_notes=catalyst,
+    )
+
+
+def enrich_signals(signals: list[Signal]) -> list[dict]:
+    """
+    Return each signal as a dict with a nested `thesis` key containing
+    the four structured thesis fields.
+    """
+    result = []
+    for sig in signals:
+        thesis = generate_thesis(sig)
+        d = sig.model_dump()
+        d["thesis_structured"] = thesis.to_dict()
+        result.append(d)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _rng_for(signal: Signal) -> random.Random:
+    key = f"{signal.symbol}:{signal.direction}:{signal.timeframe}:{signal.confidence}"
+    seed = int(hashlib.sha256(key.encode()).hexdigest(), 16) % (2 ** 32)
+    return random.Random(seed)
+
+
+def _top_feature(signal: Signal) -> tuple[str, int]:
+    if signal.top_features:
+        name, weight = signal.top_features[0]
+        return name, int(round(weight * 100))
+    return "model_score", 50

--- a/scripts/generate_signals.py
+++ b/scripts/generate_signals.py
@@ -21,9 +21,16 @@ Usage
 import argparse
 import hashlib
 import json
+import logging
 import random
 from datetime import datetime, timezone
 from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+log = logging.getLogger("generate_signals")
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 
@@ -269,18 +276,32 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    log.info(
+        "event=generation_start asset_count=%d dry_run=%s",
+        args.assets,
+        args.dry_run,
+    )
+
     snapshot = generate(asset_count=args.assets)
     payload  = json.dumps(snapshot, indent=2)
 
     if args.dry_run:
+        log.info(
+            "event=generation_complete signal_count=%d generated_at=%s dry_run=true",
+            len(snapshot["signals"]),
+            snapshot["generated_at"],
+        )
         print(payload)
         return
 
     SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
     SNAPSHOT_PATH.write_text(payload + "\n", encoding="utf-8")
-    print(
-        f"[generate_signals] wrote {len(snapshot['signals'])} signals"
-        f" to {SNAPSHOT_PATH}  (generated_at={snapshot['generated_at']})"
+    log.info(
+        "event=snapshot_written signal_count=%d path=%s generated_at=%s model_version=%s",
+        len(snapshot["signals"]),
+        SNAPSHOT_PATH,
+        snapshot["generated_at"],
+        snapshot["model_version"],
     )
 
 

--- a/scripts/generate_signals.py
+++ b/scripts/generate_signals.py
@@ -45,7 +45,9 @@ ASSETS = [
     "SHIB", "PEPE", "WIF", "BONK", "LTC",
 ]
 
-TIMEFRAMES = ["15m", "1h", "4h"]
+TIMEFRAMES = ["5m", "15m", "1h", "4h"]
+# Timeframes included in multi-TF confluence evaluation
+CONFLUENCE_TIMEFRAMES = ["5m", "15m", "1h"]
 
 # ── Feature pools by direction ─────────────────────────────────────────────────
 
@@ -167,10 +169,14 @@ def _seed_rng(symbol: str, bucket: int) -> random.Random:
     return random.Random(seed)
 
 
-def _build_signal(symbol: str, now: datetime) -> dict:
+def _build_signal(symbol: str, now: datetime, timeframe: str | None = None) -> dict:
     """Generate one synthetic signal, stable within the current UTC hour."""
     bucket = _hour_bucket(now)
-    rng    = _seed_rng(symbol, bucket)
+    # Include timeframe in seed so per-TF signals are independently seeded
+    seed_key = f"{symbol}:{bucket}:{timeframe or ''}"
+    rng = random.Random(
+        int(hashlib.sha256(seed_key.encode()).hexdigest(), 16) % (2 ** 32)
+    )
 
     # Direction: slight LONG bias reflects typical bull-market training data
     direction = rng.choices(
@@ -178,7 +184,8 @@ def _build_signal(symbol: str, now: datetime) -> dict:
         weights=[0.45, 0.30, 0.25],
     )[0]
 
-    timeframe = rng.choice(TIMEFRAMES)
+    if timeframe is None:
+        timeframe = rng.choice(TIMEFRAMES)
     regime    = rng.choice(_REGIMES[direction])
 
     # Confidence bands by direction
@@ -229,24 +236,34 @@ def _build_signal(symbol: str, now: datetime) -> dict:
 
 # ── Public API ─────────────────────────────────────────────────────────────────
 
-def generate(asset_count: int = 12) -> dict:
+def generate(asset_count: int = 12, multi_timeframe: bool = False) -> dict:
     """
     Generate a full v2 snapshot envelope.
 
-    Returns a dict ready to be JSON-serialised.  The asset subset and all
-    signal values are stable within the current UTC hour; running the script
-    twice in the same hour produces identical output.
+    When multi_timeframe=True each asset gets one signal per confluence
+    timeframe (5m, 15m, 1h), enabling the confluence engine to evaluate
+    cross-TF agreement. When False (default) one signal per asset is
+    generated with a randomly chosen timeframe.
+
+    Returns a dict ready to be JSON-serialised. Asset selection and all
+    signal values are stable within the current UTC hour.
     """
     now    = datetime.now(timezone.utc)
     bucket = _hour_bucket(now)
 
-    # Stable asset selection for this hour window
     sel_rng = random.Random(
         int(hashlib.sha256(f"select:{bucket}".encode()).hexdigest(), 16) % (2 ** 32)
     )
     assets = sorted(sel_rng.sample(ASSETS, min(asset_count, len(ASSETS))))
 
-    signals = [_build_signal(symbol, now) for symbol in assets]
+    if multi_timeframe:
+        signals = [
+            _build_signal(symbol, now, timeframe=tf)
+            for symbol in assets
+            for tf in CONFLUENCE_TIMEFRAMES
+        ]
+    else:
+        signals = [_build_signal(symbol, now) for symbol in assets]
 
     return {
         "generated_at":  now.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -274,15 +291,21 @@ def main() -> None:
         metavar="N",
         help="Number of assets to include per run (default: 12, max: %(default)s)",
     )
+    parser.add_argument(
+        "--multi-timeframe",
+        action="store_true",
+        help="Generate one signal per asset per confluence timeframe (5m, 15m, 1h)",
+    )
     args = parser.parse_args()
 
     log.info(
-        "event=generation_start asset_count=%d dry_run=%s",
+        "event=generation_start asset_count=%d dry_run=%s multi_timeframe=%s",
         args.assets,
         args.dry_run,
+        args.multi_timeframe,
     )
 
-    snapshot = generate(asset_count=args.assets)
+    snapshot = generate(asset_count=args.assets, multi_timeframe=args.multi_timeframe)
     payload  = json.dumps(snapshot, indent=2)
 
     if args.dry_run:

--- a/tests/test_confluence_engine.py
+++ b/tests/test_confluence_engine.py
@@ -1,0 +1,180 @@
+"""Tests for the multi-timeframe confluence engine."""
+
+import pytest
+
+from app.domain.signals import Direction, Signal, Timeframe
+from app.services.confluence_engine import evaluate_confluence, filter_confluent, _elevate
+
+
+def _sig(symbol="ETH", direction="LONG", timeframe="15m", confidence=0.70, regime="uptrend"):
+    return Signal(
+        symbol=symbol,
+        direction=direction,
+        timeframe=timeframe,
+        confidence=confidence,
+        regime=regime,
+        thesis="Test thesis.",
+    )
+
+
+class TestElevate:
+    def test_single_signal_returns_unchanged(self):
+        sig = _sig()
+        result = _elevate([sig])
+        assert len(result) == 1
+        assert result[0].confluence is None
+
+    def test_full_confluence_three_timeframes(self):
+        sigs = [
+            _sig(timeframe="5m",  confidence=0.65),
+            _sig(timeframe="15m", confidence=0.70),
+            _sig(timeframe="1h",  confidence=0.72),
+        ]
+        result = _elevate(sigs)
+        assert len(result) == 1
+        assert result[0].confluence == "full"
+
+    def test_full_confluence_picks_highest_confidence(self):
+        sigs = [
+            _sig(timeframe="5m",  confidence=0.65),
+            _sig(timeframe="15m", confidence=0.80),
+            _sig(timeframe="1h",  confidence=0.72),
+        ]
+        result = _elevate(sigs)
+        # Primary is the 15m (highest raw), boosted by 0.10
+        assert result[0].confidence == min(round(0.80 + 0.10, 2), 0.95)
+
+    def test_full_confluence_confidence_capped_at_0_95(self):
+        sigs = [
+            _sig(timeframe="5m",  confidence=0.90),
+            _sig(timeframe="15m", confidence=0.91),
+            _sig(timeframe="1h",  confidence=0.92),
+        ]
+        result = _elevate(sigs)
+        assert result[0].confidence == 0.95
+
+    def test_partial_confluence_two_timeframes(self):
+        sigs = [
+            _sig(timeframe="5m",  confidence=0.65),
+            _sig(timeframe="15m", confidence=0.70),
+            _sig(timeframe="1h",  confidence=0.60, direction="SHORT"),
+        ]
+        result = _elevate(sigs)
+        assert len(result) == 1
+        assert result[0].confluence == "partial"
+
+    def test_partial_confidence_boost(self):
+        sigs = [
+            _sig(timeframe="5m",  confidence=0.70),
+            _sig(timeframe="15m", confidence=0.75),
+            _sig(timeframe="1h",  confidence=0.60, direction="SHORT"),
+        ]
+        result = _elevate(sigs)
+        assert result[0].confidence == min(round(0.75 + 0.05, 2), 0.90)
+
+    def test_partial_confluence_capped_at_0_90(self):
+        sigs = [
+            _sig(timeframe="5m",  confidence=0.88),
+            _sig(timeframe="15m", confidence=0.88),
+            _sig(timeframe="1h",  confidence=0.60, direction="SHORT"),
+        ]
+        result = _elevate(sigs)
+        assert result[0].confidence == 0.90
+
+    def test_no_confluence_different_directions(self):
+        sigs = [
+            _sig(timeframe="5m",  direction="LONG",  confidence=0.70),
+            _sig(timeframe="15m", direction="SHORT", confidence=0.70),
+            _sig(timeframe="1h",  direction="FLAT",  confidence=0.50),
+        ]
+        result = _elevate(sigs)
+        # One direction per TF, no majority — returns all unchanged
+        assert all(s.confluence is None for s in result)
+
+    def test_all_flat_no_confluence(self):
+        sigs = [
+            _sig(timeframe="5m",  direction="FLAT", confidence=0.50),
+            _sig(timeframe="15m", direction="FLAT", confidence=0.52),
+        ]
+        result = _elevate(sigs)
+        assert all(s.confluence is None for s in result)
+
+    def test_confluence_timeframes_field_set(self):
+        sigs = [
+            _sig(timeframe="5m",  confidence=0.65),
+            _sig(timeframe="15m", confidence=0.70),
+            _sig(timeframe="1h",  confidence=0.72),
+        ]
+        result = _elevate(sigs)
+        assert set(result[0].confluence_timeframes) == {"5m", "15m", "1h"}
+
+
+class TestEvaluateConfluence:
+    def test_single_timeframe_signals_pass_through(self):
+        sigs = [_sig("ETH", timeframe="15m"), _sig("BTC", timeframe="15m")]
+        result = evaluate_confluence(sigs)
+        assert len(result) == 2
+        assert all(s.confluence is None for s in result)
+
+    def test_4h_signals_pass_through_untouched(self):
+        sig = _sig("BTC", timeframe="4h")
+        result = evaluate_confluence([sig])
+        assert len(result) == 1
+        assert result[0].confluence is None
+        assert result[0].timeframe == "4h"
+
+    def test_multi_symbol_each_evaluated_independently(self):
+        sigs = [
+            _sig("ETH", timeframe="5m",  confidence=0.70),
+            _sig("ETH", timeframe="15m", confidence=0.72),
+            _sig("ETH", timeframe="1h",  confidence=0.68),
+            _sig("BTC", timeframe="5m",  confidence=0.65, direction="SHORT"),
+            _sig("BTC", timeframe="15m", confidence=0.67, direction="SHORT"),
+            _sig("BTC", timeframe="1h",  confidence=0.63, direction="SHORT"),
+        ]
+        result = evaluate_confluence(sigs)
+        # Should collapse to one elevated signal per symbol
+        assert len(result) == 2
+        symbols = {s.symbol for s in result}
+        assert symbols == {"ETH", "BTC"}
+        for s in result:
+            assert s.confluence == "full"
+
+    def test_mixed_confluent_and_non_confluent(self):
+        sigs = [
+            # ETH: full confluence
+            _sig("ETH", timeframe="5m",  confidence=0.70),
+            _sig("ETH", timeframe="15m", confidence=0.72),
+            _sig("ETH", timeframe="1h",  confidence=0.68),
+            # SOL: single TF only
+            _sig("SOL", timeframe="15m", confidence=0.65),
+        ]
+        result = evaluate_confluence(sigs)
+        eth = next(s for s in result if s.symbol == "ETH")
+        sol = next(s for s in result if s.symbol == "SOL")
+        assert eth.confluence == "full"
+        assert sol.confluence is None
+
+    def test_empty_input(self):
+        assert evaluate_confluence([]) == []
+
+
+class TestFilterConfluent:
+    def test_keeps_only_confluent(self):
+        sigs = [
+            _sig("ETH", timeframe="5m",  confidence=0.70),
+            _sig("ETH", timeframe="15m", confidence=0.72),
+            _sig("ETH", timeframe="1h",  confidence=0.68),
+            _sig("BTC", timeframe="15m", confidence=0.65),
+        ]
+        evaluated = evaluate_confluence(sigs)
+        filtered = filter_confluent(evaluated)
+        assert all(s.confluence is not None for s in filtered)
+        symbols = {s.symbol for s in filtered}
+        assert "ETH" in symbols
+        assert "BTC" not in symbols
+
+    def test_empty_when_no_confluence(self):
+        sigs = [_sig("ETH", timeframe="15m")]
+        evaluated = evaluate_confluence(sigs)
+        assert filter_confluent(evaluated) == []

--- a/tests/test_digest_generator.py
+++ b/tests/test_digest_generator.py
@@ -1,0 +1,226 @@
+"""Tests for the daily signal digest generator."""
+
+import pytest
+
+from app.domain.signals import Direction, Signal, Timeframe
+from app.services.digest_generator import (
+    MarketSummary,
+    SetupSummary,
+    SignalDigest,
+    _build_market_summary,
+    _build_strongest_setups,
+    _headline,
+    _render_digest,
+    generate_digest,
+)
+
+
+def _sig(
+    symbol="ETH",
+    direction="LONG",
+    timeframe="15m",
+    confidence=0.74,
+    regime="uptrend",
+    top_features=None,
+):
+    return Signal(
+        symbol=symbol,
+        direction=direction,
+        timeframe=timeframe,
+        confidence=confidence,
+        regime=regime,
+        thesis="Original thesis.",
+        top_features=top_features or [("rsi_14", 0.18)],
+    )
+
+
+_LONG_SIGS = [
+    _sig("ETH", "LONG", confidence=0.80),
+    _sig("SOL", "LONG", confidence=0.75),
+    _sig("INJ", "LONG", confidence=0.72),
+    _sig("AVAX", "LONG", confidence=0.68),
+]
+_SHORT_SIGS = [
+    _sig("DOGE", "SHORT", confidence=0.63, regime="downtrend"),
+]
+_FLAT_SIGS = [
+    _sig("BTC", "FLAT", confidence=0.51, regime="ranging"),
+]
+_MIXED = _LONG_SIGS + _SHORT_SIGS + _FLAT_SIGS
+
+
+class TestBuildMarketSummary:
+    def test_empty_signals_neutral(self):
+        m = _build_market_summary([])
+        assert m.tone == "neutral"
+        assert m.total == 0
+
+    def test_counts_correct(self):
+        m = _build_market_summary(_MIXED)
+        assert m.long_count == 4
+        assert m.short_count == 1
+        assert m.flat_count == 1
+        assert m.total == 6
+
+    def test_bullish_tone_when_long_dominant(self):
+        sigs = [_sig(direction="LONG")] * 6 + [_sig(direction="SHORT")] * 2
+        m = _build_market_summary(sigs)
+        assert m.tone == "bullish"
+
+    def test_bearish_tone_when_short_dominant(self):
+        sigs = [_sig(direction="SHORT")] * 6 + [_sig(direction="LONG")] * 2
+        m = _build_market_summary(sigs)
+        assert m.tone == "bearish"
+
+    def test_mixed_tone_when_balanced(self):
+        sigs = [_sig(direction="LONG")] * 3 + [_sig(direction="SHORT")] * 3
+        m = _build_market_summary(sigs)
+        assert m.tone == "mixed"
+
+    def test_avg_confidence_computed(self):
+        sigs = [_sig(confidence=0.60), _sig(confidence=0.80)]
+        m = _build_market_summary(sigs)
+        assert m.avg_confidence == pytest.approx(0.70, abs=0.01)
+
+    def test_top_regime_most_common(self):
+        sigs = [
+            _sig(regime="uptrend"),
+            _sig(regime="uptrend"),
+            _sig(regime="ranging"),
+        ]
+        m = _build_market_summary(sigs)
+        assert m.top_regime == "uptrend"
+
+    def test_summary_line_non_empty(self):
+        m = _build_market_summary(_MIXED)
+        assert len(m.summary_line) > 10
+
+    def test_summary_line_deterministic(self):
+        m1 = _build_market_summary(_MIXED)
+        m2 = _build_market_summary(_MIXED)
+        assert m1.summary_line == m2.summary_line
+
+
+class TestBuildStrongestSetups:
+    def test_returns_list_of_setup_summary(self):
+        result = _build_strongest_setups(_MIXED, top_n=3)
+        assert all(isinstance(s, SetupSummary) for s in result)
+
+    def test_top_n_respected(self):
+        result = _build_strongest_setups(_MIXED, top_n=3)
+        assert len(result) <= 3
+
+    def test_sorted_by_confidence_descending(self):
+        result = _build_strongest_setups(_MIXED, top_n=10)
+        confidences = [s.signal.confidence for s in result]
+        assert confidences == sorted(confidences, reverse=True)
+
+    def test_flat_signals_excluded(self):
+        result = _build_strongest_setups(_FLAT_SIGS + _LONG_SIGS, top_n=10)
+        for s in result:
+            assert s.signal.direction != "FLAT"
+
+    def test_empty_signals_returns_empty(self):
+        assert _build_strongest_setups([], top_n=5) == []
+
+    def test_all_flat_returns_empty(self):
+        assert _build_strongest_setups(_FLAT_SIGS, top_n=5) == []
+
+    def test_thesis_is_populated(self):
+        result = _build_strongest_setups(_LONG_SIGS, top_n=2)
+        for s in result:
+            assert s.thesis.setup_rationale
+            assert s.thesis.invalidation
+
+    def test_headline_non_empty(self):
+        result = _build_strongest_setups(_LONG_SIGS, top_n=2)
+        for s in result:
+            assert len(s.headline) > 5
+
+
+class TestHeadline:
+    def test_contains_symbol(self):
+        h = _headline(_sig(symbol="ETH"))
+        assert "ETH" in h
+
+    def test_contains_timeframe(self):
+        h = _headline(_sig(timeframe="1h"))
+        assert "1h" in h
+
+    def test_long_headline_no_short_words(self):
+        h = _headline(_sig(direction="LONG"))
+        assert "SHORT" not in h
+
+    def test_short_headline_no_long_buy_words(self):
+        h = _headline(_sig(direction="SHORT"))
+        assert "LONG" not in h
+
+    def test_deterministic(self):
+        sig = _sig()
+        assert _headline(sig) == _headline(sig)
+
+
+class TestRenderDigest:
+    def _market(self):
+        return _build_market_summary(_MIXED)
+
+    def _setups(self):
+        return _build_strongest_setups(_MIXED, top_n=3)
+
+    def test_returns_string(self):
+        result = _render_digest(self._market(), self._setups(), "2026-05-01T12:00:00Z")
+        assert isinstance(result, str)
+
+    def test_contains_date(self):
+        result = _render_digest(self._market(), self._setups(), "2026-05-01T12:00:00Z")
+        assert "2026-05-01" in result
+
+    def test_contains_market_overview_header(self):
+        result = _render_digest(self._market(), self._setups(), "2026-05-01T12:00:00Z")
+        assert "## Market Overview" in result
+
+    def test_contains_strongest_setups_header(self):
+        result = _render_digest(self._market(), self._setups(), "2026-05-01T12:00:00Z")
+        assert "## Strongest Setups" in result
+
+    def test_contains_disclaimer(self):
+        result = _render_digest(self._market(), self._setups(), "2026-05-01T12:00:00Z")
+        assert "Not financial advice" in result
+
+    def test_empty_setups_placeholder(self):
+        result = _render_digest(self._market(), [], "2026-05-01T12:00:00Z")
+        assert "No directional setups" in result
+
+
+class TestGenerateDigest:
+    def test_returns_signal_digest(self):
+        result = generate_digest(_MIXED)
+        assert isinstance(result, SignalDigest)
+
+    def test_generated_at_set(self):
+        result = generate_digest(_MIXED)
+        assert result.generated_at
+
+    def test_market_summary_populated(self):
+        result = generate_digest(_MIXED)
+        assert result.market_summary.total == len(_MIXED)
+
+    def test_strongest_setups_limited(self):
+        result = generate_digest(_MIXED, top_n=2)
+        assert len(result.strongest_setups) <= 2
+
+    def test_digest_content_is_string(self):
+        result = generate_digest(_MIXED)
+        assert isinstance(result.digest_content, str)
+        assert len(result.digest_content) > 100
+
+    def test_empty_signals(self):
+        result = generate_digest([])
+        assert result.market_summary.tone == "neutral"
+        assert result.strongest_setups == []
+
+    def test_digest_content_contains_symbol_of_top_setup(self):
+        result = generate_digest(_MIXED, top_n=1)
+        if result.strongest_setups:
+            symbol = result.strongest_setups[0].signal.symbol
+            assert symbol in result.digest_content

--- a/tests/test_generate_signals.py
+++ b/tests/test_generate_signals.py
@@ -1,0 +1,191 @@
+"""Tests for the signal generation pipeline (scripts/generate_signals.py)."""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make the repo root importable so scripts/ can be reached
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.generate_signals import (
+    ASSETS,
+    TIMEFRAMES,
+    _build_signal,
+    _hour_bucket,
+    _seed_rng,
+    generate,
+    main,
+)
+
+
+_NOW = datetime(2026, 5, 1, 14, 0, 0, tzinfo=timezone.utc)
+
+
+class TestHourBucket:
+    def test_returns_int(self):
+        assert isinstance(_hour_bucket(_NOW), int)
+
+    def test_same_hour_same_bucket(self):
+        a = datetime(2026, 5, 1, 14, 0, 0, tzinfo=timezone.utc)
+        b = datetime(2026, 5, 1, 14, 59, 59, tzinfo=timezone.utc)
+        assert _hour_bucket(a) == _hour_bucket(b)
+
+    def test_different_hour_different_bucket(self):
+        a = datetime(2026, 5, 1, 14, 0, 0, tzinfo=timezone.utc)
+        b = datetime(2026, 5, 1, 15, 0, 0, tzinfo=timezone.utc)
+        assert _hour_bucket(a) != _hour_bucket(b)
+
+    def test_different_day_different_bucket(self):
+        a = datetime(2026, 5, 1, 14, 0, 0, tzinfo=timezone.utc)
+        b = datetime(2026, 5, 2, 14, 0, 0, tzinfo=timezone.utc)
+        assert _hour_bucket(a) != _hour_bucket(b)
+
+
+class TestSeedRng:
+    def test_same_inputs_same_sequence(self):
+        bucket = _hour_bucket(_NOW)
+        r1 = _seed_rng("BTC", bucket)
+        r2 = _seed_rng("BTC", bucket)
+        assert r1.random() == r2.random()
+
+    def test_different_symbols_different_sequence(self):
+        bucket = _hour_bucket(_NOW)
+        r1 = _seed_rng("BTC", bucket)
+        r2 = _seed_rng("ETH", bucket)
+        assert r1.random() != r2.random()
+
+    def test_different_buckets_different_sequence(self):
+        r1 = _seed_rng("BTC", 1000)
+        r2 = _seed_rng("BTC", 2000)
+        assert r1.random() != r2.random()
+
+
+class TestBuildSignal:
+    def test_returns_required_keys(self):
+        sig = _build_signal("ETH", _NOW)
+        for key in ("symbol", "direction", "timeframe", "confidence", "regime", "thesis", "top_features"):
+            assert key in sig, f"Missing key: {key}"
+
+    def test_symbol_preserved(self):
+        assert _build_signal("BTC", _NOW)["symbol"] == "BTC"
+
+    def test_direction_valid(self):
+        sig = _build_signal("ETH", _NOW)
+        assert sig["direction"] in ("LONG", "SHORT", "FLAT")
+
+    def test_timeframe_valid(self):
+        sig = _build_signal("ETH", _NOW)
+        assert sig["timeframe"] in TIMEFRAMES
+
+    def test_confidence_long_range(self):
+        # Sample many symbols to hit LONG direction and check range
+        for symbol in ASSETS:
+            sig = _build_signal(symbol, _NOW)
+            if sig["direction"] == "LONG":
+                assert 0.58 <= sig["confidence"] <= 0.85, sig
+
+    def test_confidence_short_range(self):
+        for symbol in ASSETS:
+            sig = _build_signal(symbol, _NOW)
+            if sig["direction"] == "SHORT":
+                assert 0.55 <= sig["confidence"] <= 0.80, sig
+
+    def test_confidence_flat_range(self):
+        for symbol in ASSETS:
+            sig = _build_signal(symbol, _NOW)
+            if sig["direction"] == "FLAT":
+                assert 0.40 <= sig["confidence"] <= 0.60, sig
+
+    def test_top_features_is_list(self):
+        sig = _build_signal("ETH", _NOW)
+        assert isinstance(sig["top_features"], list)
+
+    def test_top_features_count(self):
+        sig = _build_signal("ETH", _NOW)
+        assert 2 <= len(sig["top_features"]) <= 4
+
+    def test_top_features_structure(self):
+        sig = _build_signal("ETH", _NOW)
+        for feat in sig["top_features"]:
+            assert len(feat) == 2
+            assert isinstance(feat[0], str)
+            assert isinstance(feat[1], float)
+
+    def test_deterministic_same_hour(self):
+        a = _build_signal("SOL", _NOW)
+        b = _build_signal("SOL", _NOW)
+        assert a == b
+
+    def test_different_hour_may_differ(self):
+        t2 = datetime(2026, 5, 1, 15, 0, 0, tzinfo=timezone.utc)
+        a = _build_signal("SOL", _NOW)
+        b = _build_signal("SOL", t2)
+        # Different hours use different seeds — very unlikely to be identical
+        assert a != b
+
+
+class TestGenerate:
+    def test_returns_required_keys(self):
+        snap = generate(asset_count=5)
+        for key in ("generated_at", "model_version", "source", "signals"):
+            assert key in snap
+
+    def test_model_version(self):
+        assert generate(asset_count=3)["model_version"] == "synthetic-v1"
+
+    def test_source(self):
+        assert generate(asset_count=3)["source"] == "generated"
+
+    def test_generated_at_format(self):
+        ts = generate(asset_count=3)["generated_at"]
+        # Should parse as ISO 8601
+        datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+
+    def test_signal_count_respected(self):
+        for n in (1, 5, 10):
+            snap = generate(asset_count=n)
+            assert len(snap["signals"]) == n
+
+    def test_max_signal_count_capped_by_asset_universe(self):
+        snap = generate(asset_count=1000)
+        assert len(snap["signals"]) == len(ASSETS)
+
+    def test_signals_are_valid_dicts(self):
+        snap = generate(asset_count=5)
+        for sig in snap["signals"]:
+            assert sig["direction"] in ("LONG", "SHORT", "FLAT")
+            assert 0.0 <= sig["confidence"] <= 1.0
+
+    def test_deterministic_within_hour(self):
+        a = generate(asset_count=8)
+        b = generate(asset_count=8)
+        assert a["signals"] == b["signals"]
+
+    def test_json_serializable(self):
+        snap = generate(asset_count=5)
+        payload = json.dumps(snap)
+        assert json.loads(payload)["model_version"] == "synthetic-v1"
+
+
+class TestMain:
+    def test_dry_run_prints_json(self, capsys):
+        with patch("sys.argv", ["generate_signals.py", "--dry-run", "--assets", "3"]):
+            main()
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data["signals"]) == 3
+
+    def test_write_creates_file(self, tmp_path):
+        snapshot_target = tmp_path / "signals_snapshot.json"
+        with (
+            patch("sys.argv", ["generate_signals.py", "--assets", "4"]),
+            patch("scripts.generate_signals.SNAPSHOT_PATH", snapshot_target),
+        ):
+            main()
+        assert snapshot_target.exists()
+        data = json.loads(snapshot_target.read_text())
+        assert len(data["signals"]) == 4

--- a/tests/test_signal_domain.py
+++ b/tests/test_signal_domain.py
@@ -1,0 +1,93 @@
+"""Tests for the Signal domain model (app/domain/signals.py)."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.domain.signals import Direction, Signal, Timeframe
+
+
+class TestDirection:
+    def test_values(self):
+        assert Direction.LONG == "LONG"
+        assert Direction.SHORT == "SHORT"
+        assert Direction.FLAT == "FLAT"
+
+    def test_all_members(self):
+        assert set(Direction) == {Direction.LONG, Direction.SHORT, Direction.FLAT}
+
+
+class TestTimeframe:
+    def test_values(self):
+        assert Timeframe.M15 == "15m"
+        assert Timeframe.H1 == "1h"
+        assert Timeframe.H4 == "4h"
+
+
+class TestSignalValidation:
+    _valid = dict(
+        symbol="ETH",
+        direction="LONG",
+        timeframe="15m",
+        confidence=0.72,
+        regime="uptrend",
+        thesis="RSI reset from oversold.",
+    )
+
+    def test_valid_signal_parses(self):
+        s = Signal(**self._valid)
+        assert s.symbol == "ETH"
+        assert s.direction == "LONG"
+        assert s.confidence == 0.72
+
+    def test_confidence_lower_bound(self):
+        s = Signal(**{**self._valid, "confidence": 0.0})
+        assert s.confidence == 0.0
+
+    def test_confidence_upper_bound(self):
+        s = Signal(**{**self._valid, "confidence": 1.0})
+        assert s.confidence == 1.0
+
+    def test_confidence_below_zero_rejected(self):
+        with pytest.raises(ValidationError):
+            Signal(**{**self._valid, "confidence": -0.01})
+
+    def test_confidence_above_one_rejected(self):
+        with pytest.raises(ValidationError):
+            Signal(**{**self._valid, "confidence": 1.01})
+
+    def test_invalid_direction_rejected(self):
+        with pytest.raises(ValidationError):
+            Signal(**{**self._valid, "direction": "MAYBE"})
+
+    def test_invalid_timeframe_rejected(self):
+        with pytest.raises(ValidationError):
+            Signal(**{**self._valid, "timeframe": "5m"})
+
+    def test_top_features_optional(self):
+        s = Signal(**self._valid)
+        assert s.top_features is None
+
+    def test_top_features_accepted(self):
+        feats = [("rsi_14", 0.18), ("macd_hist", 0.12)]
+        s = Signal(**{**self._valid, "top_features": feats})
+        assert s.top_features == feats
+
+    def test_model_validate_from_dict(self):
+        s = Signal.model_validate(self._valid)
+        assert s.symbol == "ETH"
+
+    def test_missing_required_field_rejected(self):
+        data = dict(self._valid)
+        del data["symbol"]
+        with pytest.raises(ValidationError):
+            Signal(**data)
+
+    @pytest.mark.parametrize("direction", ["LONG", "SHORT", "FLAT"])
+    def test_all_directions_accepted(self, direction):
+        s = Signal(**{**self._valid, "direction": direction})
+        assert s.direction == direction
+
+    @pytest.mark.parametrize("timeframe", ["15m", "1h", "4h"])
+    def test_all_timeframes_accepted(self, timeframe):
+        s = Signal(**{**self._valid, "timeframe": timeframe})
+        assert s.timeframe == timeframe

--- a/tests/test_signal_domain.py
+++ b/tests/test_signal_domain.py
@@ -61,7 +61,7 @@ class TestSignalValidation:
 
     def test_invalid_timeframe_rejected(self):
         with pytest.raises(ValidationError):
-            Signal(**{**self._valid, "timeframe": "5m"})
+            Signal(**{**self._valid, "timeframe": "30m"})
 
     def test_top_features_optional(self):
         s = Signal(**self._valid)
@@ -87,7 +87,7 @@ class TestSignalValidation:
         s = Signal(**{**self._valid, "direction": direction})
         assert s.direction == direction
 
-    @pytest.mark.parametrize("timeframe", ["15m", "1h", "4h"])
+    @pytest.mark.parametrize("timeframe", ["5m", "15m", "1h", "4h"])
     def test_all_timeframes_accepted(self, timeframe):
         s = Signal(**{**self._valid, "timeframe": timeframe})
         assert s.timeframe == timeframe

--- a/tests/test_signal_repository.py
+++ b/tests/test_signal_repository.py
@@ -1,0 +1,155 @@
+"""Tests for the signal repository layer (app/repositories/signal_repository.py)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.repositories.signal_repository import (
+    SignalSnapshot,
+    _error_snapshot,
+    _parse_snapshot,
+    get_signals_from_file,
+)
+
+
+_VALID_SIGNAL = {
+    "symbol": "ETH",
+    "direction": "LONG",
+    "timeframe": "15m",
+    "confidence": 0.72,
+    "regime": "uptrend",
+    "thesis": "RSI reset from oversold.",
+}
+
+
+class TestErrorSnapshot:
+    def test_returns_snapshot(self):
+        snap = _error_snapshot("test", "something went wrong")
+        assert isinstance(snap, SignalSnapshot)
+
+    def test_status_is_error(self):
+        snap = _error_snapshot("test", "boom")
+        assert snap.status == "error"
+
+    def test_signals_empty(self):
+        snap = _error_snapshot("test", "boom")
+        assert snap.signals == []
+
+    def test_error_message_preserved(self):
+        snap = _error_snapshot("test", "boom")
+        assert snap.error_message == "boom"
+
+    def test_source_preserved(self):
+        snap = _error_snapshot("mysource", "x")
+        assert snap.source == "mysource"
+
+
+class TestParseSnapshot:
+    def test_v2_object_format(self):
+        raw = {
+            "generated_at": "2026-05-01T12:00:00Z",
+            "model_version": "xgboost-v1",
+            "source": "sentinel",
+            "signals": [_VALID_SIGNAL],
+        }
+        snap = _parse_snapshot(raw, "sentinel")
+        assert len(snap.signals) == 1
+        assert snap.generated_at == "2026-05-01T12:00:00Z"
+        assert snap.model_version == "xgboost-v1"
+
+    def test_v1_bare_array_format(self):
+        snap = _parse_snapshot([_VALID_SIGNAL], "local_snapshot")
+        assert len(snap.signals) == 1
+
+    def test_invalid_record_skipped(self):
+        bad = {"symbol": "BAD", "direction": "MAYBE", "confidence": 5.0, "regime": "x", "thesis": "y"}
+        snap = _parse_snapshot({"signals": [_VALID_SIGNAL, bad]}, "test")
+        assert len(snap.signals) == 1
+        assert snap.signals[0].symbol == "ETH"
+
+    def test_all_invalid_records_returns_empty_signals(self):
+        bad = {"symbol": "X", "direction": "MAYBE", "confidence": 9.9, "regime": "x", "thesis": "y"}
+        snap = _parse_snapshot({"signals": [bad]}, "test")
+        assert snap.signals == []
+
+    def test_empty_signals_array(self):
+        snap = _parse_snapshot({"signals": []}, "test")
+        assert snap.signals == []
+
+    def test_status_ok(self):
+        snap = _parse_snapshot([_VALID_SIGNAL], "local_snapshot")
+        assert snap.status == "ok"
+
+    def test_invalid_root_type_raises(self):
+        with pytest.raises(ValueError):
+            _parse_snapshot("not-a-dict-or-list", "test")
+
+    def test_signals_key_not_a_list_raises(self):
+        with pytest.raises(ValueError):
+            _parse_snapshot({"signals": "should-be-a-list"}, "test")
+
+    def test_source_falls_back_to_label(self):
+        raw = {"signals": [_VALID_SIGNAL]}  # no "source" key
+        snap = _parse_snapshot(raw, "my_label")
+        assert snap.source == "my_label"
+
+    def test_multiple_signals_all_parsed(self):
+        raw = {"signals": [_VALID_SIGNAL, {**_VALID_SIGNAL, "symbol": "BTC"}]}
+        snap = _parse_snapshot(raw, "test")
+        assert len(snap.signals) == 2
+
+
+class TestGetSignalsFromFile:
+    def _write_snapshot(self, path: Path, data) -> None:
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def test_valid_file_returns_ok(self, tmp_path):
+        f = tmp_path / "signals.json"
+        self._write_snapshot(f, {"signals": [_VALID_SIGNAL]})
+        with patch("app.repositories.signal_repository.settings") as mock_cfg:
+            mock_cfg.signal_file_path = str(f)
+            snap = get_signals_from_file()
+        assert snap.status == "ok"
+        assert len(snap.signals) == 1
+
+    def test_missing_file_returns_error(self):
+        with patch("app.repositories.signal_repository.settings") as mock_cfg:
+            mock_cfg.signal_file_path = "/nonexistent/path/signals.json"
+            snap = get_signals_from_file()
+        assert snap.status == "error"
+        assert snap.signals == []
+
+    def test_empty_path_returns_error(self):
+        with patch("app.repositories.signal_repository.settings") as mock_cfg:
+            mock_cfg.signal_file_path = ""
+            snap = get_signals_from_file()
+        assert snap.status == "error"
+
+    def test_invalid_json_returns_error(self, tmp_path):
+        f = tmp_path / "bad.json"
+        f.write_text("not-json{{{", encoding="utf-8")
+        with patch("app.repositories.signal_repository.settings") as mock_cfg:
+            mock_cfg.signal_file_path = str(f)
+            snap = get_signals_from_file()
+        assert snap.status == "error"
+
+    def test_empty_signals_array_returns_empty_status(self, tmp_path):
+        f = tmp_path / "empty.json"
+        self._write_snapshot(f, {"signals": []})
+        with patch("app.repositories.signal_repository.settings") as mock_cfg:
+            mock_cfg.signal_file_path = str(f)
+            snap = get_signals_from_file()
+        assert snap.status == "empty"
+        assert snap.signals == []
+
+    def test_v1_bare_array_accepted(self, tmp_path):
+        f = tmp_path / "v1.json"
+        self._write_snapshot(f, [_VALID_SIGNAL])
+        with patch("app.repositories.signal_repository.settings") as mock_cfg:
+            mock_cfg.signal_file_path = str(f)
+            snap = get_signals_from_file()
+        assert snap.status == "ok"
+        assert len(snap.signals) == 1

--- a/tests/test_signal_service.py
+++ b/tests/test_signal_service.py
@@ -1,0 +1,127 @@
+"""Tests for the signal service layer (app/services/signal_service.py)."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.domain.signals import Signal, Direction, Timeframe
+from app.repositories.signal_repository import SignalSnapshot
+from app.services.signal_service import get_mock_signals, get_signals
+
+
+_MOCK_SIGNAL = Signal(
+    symbol="ETH",
+    direction=Direction.LONG,
+    timeframe=Timeframe.M15,
+    confidence=0.75,
+    regime="uptrend",
+    thesis="Test thesis.",
+)
+
+_OK_SNAPSHOT = SignalSnapshot(signals=[_MOCK_SIGNAL], source="file", status="ok")
+_EMPTY_SNAPSHOT = SignalSnapshot(signals=[], source="file", status="empty")
+_ERROR_SNAPSHOT = SignalSnapshot(signals=[], source="file", status="error", error_message="load failed")
+
+
+class TestGetMockSignals:
+    def test_returns_list(self):
+        result = get_mock_signals()
+        assert isinstance(result, list)
+
+    def test_all_items_are_signals(self):
+        for sig in get_mock_signals():
+            assert isinstance(sig, Signal)
+
+    def test_non_empty(self):
+        assert len(get_mock_signals()) > 0
+
+    def test_confidence_in_range(self):
+        for sig in get_mock_signals():
+            assert 0.0 <= sig.confidence <= 1.0
+
+    def test_directions_valid(self):
+        valid = {"LONG", "SHORT", "FLAT"}
+        for sig in get_mock_signals():
+            assert sig.direction in valid
+
+
+class TestGetSignalsMockProvider:
+    def _patch_settings(self, provider="mock", environment="development", allow_fallback=True):
+        mock_cfg = MagicMock()
+        mock_cfg.signal_provider = provider
+        mock_cfg.environment = environment
+        mock_cfg.allow_mock_fallback = allow_fallback
+        return patch("app.services.signal_service.settings", mock_cfg)
+
+    def test_mock_provider_returns_signals(self):
+        with self._patch_settings(provider="mock"):
+            snap = get_signals()
+        assert len(snap.signals) > 0
+
+    def test_mock_provider_source_is_mock(self):
+        with self._patch_settings(provider="mock"):
+            snap = get_signals()
+        assert snap.source == "mock"
+
+    def test_mock_provider_no_mock_fallback_flag(self):
+        with self._patch_settings(provider="mock"):
+            snap = get_signals()
+        assert snap.used_mock_fallback is False
+
+    def test_mock_provider_status_ok(self):
+        with self._patch_settings(provider="mock"):
+            snap = get_signals()
+        assert snap.status == "ok"
+
+
+class TestGetSignalsFileProvider:
+    def _setup(self, snapshot, allow_fallback=True):
+        mock_cfg = MagicMock()
+        mock_cfg.signal_provider = "file"
+        mock_cfg.environment = "development"
+        mock_cfg.allow_mock_fallback = allow_fallback
+        return (
+            patch("app.services.signal_service.settings", mock_cfg),
+            patch("app.services.signal_service._repo_get_signals_from_file", return_value=snapshot),
+        )
+
+    def test_ok_snapshot_returned_as_is(self):
+        p1, p2 = self._setup(_OK_SNAPSHOT)
+        with p1, p2:
+            snap = get_signals()
+        assert snap.signals == [_MOCK_SIGNAL]
+        assert snap.source == "file"
+
+    def test_empty_snapshot_with_fallback_returns_mocks(self):
+        p1, p2 = self._setup(_EMPTY_SNAPSHOT, allow_fallback=True)
+        with p1, p2:
+            snap = get_signals()
+        assert snap.used_mock_fallback is True
+        assert snap.source == "mock_fallback"
+        assert len(snap.signals) > 0
+
+    def test_empty_snapshot_without_fallback_returns_empty(self):
+        p1, p2 = self._setup(_EMPTY_SNAPSHOT, allow_fallback=False)
+        with p1, p2:
+            snap = get_signals()
+        assert snap.signals == []
+        assert snap.used_mock_fallback is False
+
+    def test_error_snapshot_with_fallback_uses_mock(self):
+        p1, p2 = self._setup(_ERROR_SNAPSHOT, allow_fallback=True)
+        with p1, p2:
+            snap = get_signals()
+        assert snap.used_mock_fallback is True
+
+    def test_error_snapshot_without_fallback_returns_empty(self):
+        p1, p2 = self._setup(_ERROR_SNAPSHOT, allow_fallback=False)
+        with p1, p2:
+            snap = get_signals()
+        assert snap.signals == []
+        assert snap.status == "error"
+
+    def test_fallback_preserves_original_error_message(self):
+        p1, p2 = self._setup(_ERROR_SNAPSHOT, allow_fallback=True)
+        with p1, p2:
+            snap = get_signals()
+        assert snap.error_message == "load failed"

--- a/tests/test_signal_service.py
+++ b/tests/test_signal_service.py
@@ -82,7 +82,7 @@ class TestGetSignalsFileProvider:
         mock_cfg.allow_mock_fallback = allow_fallback
         return (
             patch("app.services.signal_service.settings", mock_cfg),
-            patch("app.services.signal_service._repo_get_signals_from_file", return_value=snapshot),
+            patch("app.providers.file_provider.get_signals", return_value=snapshot),
         )
 
     def test_ok_snapshot_returned_as_is(self):

--- a/tests/test_signal_service.py
+++ b/tests/test_signal_service.py
@@ -51,6 +51,7 @@ class TestGetSignalsMockProvider:
         mock_cfg.signal_provider = provider
         mock_cfg.environment = environment
         mock_cfg.allow_mock_fallback = allow_fallback
+        mock_cfg.signal_confluence = False
         return patch("app.services.signal_service.settings", mock_cfg)
 
     def test_mock_provider_returns_signals(self):
@@ -80,6 +81,7 @@ class TestGetSignalsFileProvider:
         mock_cfg.signal_provider = "file"
         mock_cfg.environment = "development"
         mock_cfg.allow_mock_fallback = allow_fallback
+        mock_cfg.signal_confluence = False
         return (
             patch("app.services.signal_service.settings", mock_cfg),
             patch("app.providers.file_provider.get_signals", return_value=snapshot),

--- a/tests/test_thesis_generator.py
+++ b/tests/test_thesis_generator.py
@@ -1,0 +1,154 @@
+"""Tests for the signal thesis generator."""
+
+import pytest
+
+from app.domain.signals import Direction, Signal, Timeframe
+from app.services.thesis_generator import (
+    SignalThesis,
+    _rng_for,
+    _top_feature,
+    enrich_signals,
+    generate_thesis,
+)
+
+
+def _sig(
+    symbol="ETH",
+    direction="LONG",
+    timeframe="15m",
+    confidence=0.74,
+    regime="uptrend",
+    top_features=None,
+):
+    return Signal(
+        symbol=symbol,
+        direction=direction,
+        timeframe=timeframe,
+        confidence=confidence,
+        regime=regime,
+        thesis="Original thesis.",
+        top_features=top_features or [("rsi_14", 0.18), ("macd_hist", 0.12)],
+    )
+
+
+class TestRngFor:
+    def test_same_signal_same_rng_sequence(self):
+        sig = _sig()
+        r1 = _rng_for(sig)
+        r2 = _rng_for(sig)
+        assert r1.random() == r2.random()
+
+    def test_different_symbol_different_rng(self):
+        r1 = _rng_for(_sig(symbol="ETH"))
+        r2 = _rng_for(_sig(symbol="BTC"))
+        assert r1.random() != r2.random()
+
+    def test_different_confidence_different_rng(self):
+        r1 = _rng_for(_sig(confidence=0.70))
+        r2 = _rng_for(_sig(confidence=0.80))
+        assert r1.random() != r2.random()
+
+
+class TestTopFeature:
+    def test_returns_first_feature(self):
+        sig = _sig(top_features=[("rsi_14", 0.18), ("macd_hist", 0.12)])
+        name, weight = _top_feature(sig)
+        assert name == "rsi_14"
+        assert weight == 18
+
+    def test_no_features_returns_fallback(self):
+        sig = Signal(
+            symbol="ETH", direction="LONG", timeframe="15m",
+            confidence=0.72, regime="uptrend", thesis="x",
+        )
+        name, weight = _top_feature(sig)
+        assert name == "model_score"
+        assert weight == 50
+
+    def test_weight_converted_to_percent(self):
+        sig = _sig(top_features=[("vol_ratio", 0.25)])
+        _, weight = _top_feature(sig)
+        assert weight == 25
+
+
+class TestGenerateThesis:
+    @pytest.mark.parametrize("direction", ["LONG", "SHORT", "FLAT"])
+    def test_returns_signal_thesis(self, direction):
+        sig = _sig(direction=direction)
+        result = generate_thesis(sig)
+        assert isinstance(result, SignalThesis)
+
+    @pytest.mark.parametrize("direction", ["LONG", "SHORT", "FLAT"])
+    def test_all_fields_non_empty(self, direction):
+        sig = _sig(direction=direction)
+        t = generate_thesis(sig)
+        assert t.setup_rationale
+        assert t.invalidation
+        assert t.risk_thesis
+        assert t.catalyst_notes
+
+    def test_deterministic_for_same_signal(self):
+        sig = _sig()
+        t1 = generate_thesis(sig)
+        t2 = generate_thesis(sig)
+        assert t1.setup_rationale == t2.setup_rationale
+        assert t1.invalidation == t2.invalidation
+        assert t1.risk_thesis == t2.risk_thesis
+        assert t1.catalyst_notes == t2.catalyst_notes
+
+    def test_different_signals_may_differ(self):
+        t1 = generate_thesis(_sig(symbol="ETH"))
+        t2 = generate_thesis(_sig(symbol="BTC"))
+        # Very unlikely to be identical
+        assert t1.setup_rationale != t2.setup_rationale or t1.invalidation != t2.invalidation
+
+    def test_timeframe_appears_in_output(self):
+        sig = _sig(timeframe="1h")
+        t = generate_thesis(sig)
+        combined = t.setup_rationale + t.invalidation + t.risk_thesis + t.catalyst_notes
+        assert "1h" in combined
+
+    def test_no_unfilled_placeholders(self):
+        for direction in ["LONG", "SHORT", "FLAT"]:
+            sig = _sig(direction=direction)
+            t = generate_thesis(sig)
+            for field in (t.setup_rationale, t.invalidation, t.risk_thesis, t.catalyst_notes):
+                assert "{" not in field, f"Unfilled placeholder in: {field}"
+
+    def test_to_dict_keys(self):
+        t = generate_thesis(_sig())
+        d = t.to_dict()
+        assert set(d.keys()) == {"setup_rationale", "invalidation", "risk_thesis", "catalyst_notes"}
+
+
+class TestEnrichSignals:
+    def test_returns_list_of_dicts(self):
+        result = enrich_signals([_sig()])
+        assert isinstance(result, list)
+        assert isinstance(result[0], dict)
+
+    def test_thesis_structured_key_present(self):
+        result = enrich_signals([_sig()])
+        assert "thesis_structured" in result[0]
+
+    def test_thesis_structured_has_four_fields(self):
+        structured = enrich_signals([_sig()])[0]["thesis_structured"]
+        assert set(structured.keys()) == {
+            "setup_rationale", "invalidation", "risk_thesis", "catalyst_notes"
+        }
+
+    def test_original_signal_fields_preserved(self):
+        sig = _sig(symbol="SOL", confidence=0.77)
+        result = enrich_signals([sig])[0]
+        assert result["symbol"] == "SOL"
+        assert result["confidence"] == 0.77
+
+    def test_empty_list_returns_empty(self):
+        assert enrich_signals([]) == []
+
+    def test_multiple_signals_each_enriched(self):
+        sigs = [_sig("ETH"), _sig("BTC"), _sig("SOL")]
+        result = enrich_signals(sigs)
+        assert len(result) == 3
+        for r in result:
+            assert "thesis_structured" in r


### PR DESCRIPTION
## Summary

Closes #22 and #19.

### Issue #22 — Unit tests for signal scoring

86 tests across 4 new test modules, all passing (`86 passed, 1 warning in 0.17s`).

| File | Tests | Coverage |
|------|-------|----------|
| `tests/test_signal_domain.py` | 16 | `Signal` model validation, `Direction`/`Timeframe` enums, confidence bounds, invalid field rejection |
| `tests/test_generate_signals.py` | 30 | `_hour_bucket` determinism, `_seed_rng` seeding, `_build_signal` output contract + per-direction confidence ranges, `generate()` snapshot structure + determinism, `main()` dry-run and file-write |
| `tests/test_signal_repository.py` | 21 | `_error_snapshot`, `_parse_snapshot` v1/v2 formats + invalid record skipping, `get_signals_from_file()` all error paths (missing file, bad JSON, empty path, empty signals) |
| `tests/test_signal_service.py` | 20 | `get_mock_signals()`, mock provider, file provider ok/empty/error + fallback on/off behavior, error_message propagation |

### Issue #19 — Structured logging for signal generation

Logfmt-style `event=X key=value` strings via stdlib `logging` — no added deps, grep-friendly, log-shipper-ready.

- **`scripts/generate_signals.py`**: replaced bare `print()` with `logging`; emits `event=generation_start` and `event=snapshot_written` (or `event=generation_complete` on dry-run) with `signal_count`, `path`, `generated_at`, `model_version`
- **`app/routes/signals.py`**: `event=signal_feed_render` with `signal_count`, `source`, `status`, `used_mock_fallback`, `generated_at`, `model_version`
- **`app/routes/pages.py`**: `event=health_check` with `version`, `environment`, `provider`; `event=health_signals_check` with `provider`, `sentinel_configured`

The service and repository layers already had structured logging; this completes the remaining gaps.

## Test plan

- [x] `python -m pytest tests/ -q` → 86 passed, 1 warning
- [ ] Run `python scripts/generate_signals.py --dry-run` and confirm structured log lines appear on stderr
- [ ] Run `python scripts/generate_signals.py` and confirm `event=snapshot_written` log with correct counts
- [ ] Start the app and hit `/signals` — confirm `event=signal_feed_render` in logs
- [ ] Hit `/health` and `/health/signals` — confirm `event=health_check` / `event=health_signals_check` in logs

https://claude.ai/code/session_0129CHPpPV9ZxBK3V8TPzH1U

---
_Generated by [Claude Code](https://claude.ai/code/session_0129CHPpPV9ZxBK3V8TPzH1U)_