### PR TITLE
feat(blog): blog infrastructure - routes, GCS service, templates, ingest API (closes #52)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -79,6 +79,18 @@ class Settings:
         default_factory=lambda: os.getenv("GCS_NEWS_BUCKET", "alphaforgeai-news")
     )
 
+    # ── Blog ingest API ──────────────────────────────────────────────────────
+    # Bearer token required by POST /api/blog/ingest.
+    # Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+    blog_ingest_api_key: str = field(
+        default_factory=lambda: os.getenv("BLOG_INGEST_API_KEY", "")
+    )
+
+    # ── GCS blog storage ──────────────────────────────────────────────────────
+    gcs_blog_bucket: str = field(
+        default_factory=lambda: os.getenv("GCS_BLOG_BUCKET", "alphaforgeai-blog")
+    )
+
     # ── Sentinel SSH connection ──────────────────────────────────────────────
     # Required when signal_source == "sentinel_ssh".
     sentinel_ssh_host:         str = field(default_factory=lambda: os.getenv("SENTINEL_SSH_HOST", ""))

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
 from app.core.config import settings
-from app.routes import ingest, pages, dashboard, signals, explainers, news
+from app.routes import ingest, pages, dashboard, signals, explainers, news, blog
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -24,3 +24,4 @@ app.include_router(signals.router)
 app.include_router(ingest.router)
 app.include_router(explainers.router)
 app.include_router(news.router)
+app.include_router(blog.router)

--- a/app/routes/blog.py
+++ b/app/routes/blog.py
@@ -1,0 +1,143 @@
+"""Blog routes — ingest from external pipeline + serve to frontend."""
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.templating import Jinja2Templates
+
+from app.core.config import settings
+from app.services import gcs_blog
+from app.services.gcs_blog import slugify
+
+router    = APIRouter()
+log       = logging.getLogger(__name__)
+_bearer   = HTTPBearer()
+templates = Jinja2Templates(directory=Path(__file__).resolve().parents[1] / "templates")
+
+
+def _format_pub_time(iso: str) -> str:
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return dt.strftime("%b %d, %Y %H:%M UTC")
+    except Exception:
+        return iso
+
+
+templates.env.filters["format_pub_time"] = _format_pub_time
+
+
+def _require_blog_api_key(creds: HTTPAuthorizationCredentials = Depends(_bearer)) -> None:
+    key = settings.blog_ingest_api_key
+    if not key:
+        log.error("event=blog_ingest_rejected reason=api_key_not_configured")
+        raise HTTPException(status_code=503, detail="Blog ingest endpoint not configured")
+    if creds.credentials != key:
+        log.warning("event=blog_ingest_rejected reason=invalid_api_key")
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+# ── Ingest ────────────────────────────────────────────────────────────────────
+
+@router.post("/api/blog/ingest", dependencies=[Depends(_require_blog_api_key)])
+async def ingest_blog(request: Request) -> dict:
+    """
+    Accept a blog post payload and persist to GCS.
+    Caller must supply Authorization: Bearer <BLOG_INGEST_API_KEY>.
+
+    Expected body (batch):
+      { "schema_version": 1, "posts": [ <post>, ... ] }
+
+    Or a single post dict directly (schema_version optional).
+
+    Each post requires: title, published_at, summary, content.
+    Optional: sources (list), assets (list), tags (list), author.
+    """
+    try:
+        raw = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body is not valid JSON")
+
+    # Accept single-post dict OR { schema_version, posts: [...] }
+    if isinstance(raw, dict) and "posts" not in raw and "title" in raw:
+        # Single post submitted directly
+        items = [raw]
+    else:
+        if raw.get("schema_version") != 1:
+            raise HTTPException(
+                status_code=422,
+                detail="Missing or invalid schema_version (expected 1)",
+            )
+        items = raw.get("posts", [])
+        if not items:
+            raise HTTPException(status_code=422, detail="No posts in payload")
+
+    required = {"title", "published_at", "summary", "content"}
+    valid = [
+        item for item in items
+        if isinstance(item, dict) and required.issubset(item.keys())
+    ]
+    if not valid:
+        raise HTTPException(
+            status_code=422,
+            detail="No valid posts (missing required fields: title, published_at, summary, content)",
+        )
+
+    # Ensure every post has a slug
+    for post in valid:
+        if not post.get("slug"):
+            post["slug"] = slugify(post["title"], post["published_at"])
+        if not post.get("author"):
+            post["author"] = "AlphaForgeAI"
+
+    added, total = gcs_blog.ingest_posts(valid, bucket_name=settings.gcs_blog_bucket)
+    log.info(
+        "event=blog_ingest received=%d valid=%d added=%d total=%d",
+        len(items), len(valid), added, total,
+    )
+    return {"accepted": True, "added": added, "total": total}
+
+
+# ── API ───────────────────────────────────────────────────────────────────────
+
+@router.get("/api/blog")
+async def get_blog() -> dict:
+    """Return the latest blog posts from GCS."""
+    payload = gcs_blog.download_payload(bucket_name=settings.gcs_blog_bucket)
+    if not payload:
+        return {"posts": [], "total": 0, "generated_at": None}
+    return payload
+
+
+# ── HTML pages ────────────────────────────────────────────────────────────────
+
+@router.get("/blog", response_class=HTMLResponse)
+async def blog_list_page(request: Request):
+    payload = gcs_blog.download_payload(bucket_name=settings.gcs_blog_bucket)
+    posts   = payload.get("posts", []) if payload else []
+    return templates.TemplateResponse(request, "blog_list.html", {
+        "active_page":  "blog",
+        "app_version":  settings.app_version,
+        "environment":  settings.environment,
+        "posts":        posts,
+        "total":        len(posts),
+        "generated_at": payload.get("generated_at") if payload else None,
+    })
+
+
+@router.get("/blog/{slug}", response_class=HTMLResponse)
+async def blog_post_page(slug: str, request: Request):
+    payload = gcs_blog.download_payload(bucket_name=settings.gcs_blog_bucket)
+    posts   = payload.get("posts", []) if payload else []
+    post    = next((p for p in posts if p.get("slug") == slug), None)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return templates.TemplateResponse(request, "blog_post.html", {
+        "active_page": "blog",
+        "app_version": settings.app_version,
+        "environment": settings.environment,
+        "post":        post,
+    })

--- a/app/services/gcs_blog.py
+++ b/app/services/gcs_blog.py
@@ -1,0 +1,96 @@
+"""
+GCS blog storage — read/write blog posts from Cloud Storage.
+
+Bucket: GCS_BLOG_BUCKET (default: alphaforgeai-blog)
+Object: latest.json
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+_BLOB_NAME  = "latest.json"
+_MAX_POSTS  = 50
+
+
+def _client_and_blob(bucket_name: str):
+    from google.cloud import storage  # type: ignore
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob   = bucket.blob(_BLOB_NAME)
+    return client, blob
+
+
+def slugify(title: str, published_at: str) -> str:
+    """Generate a slug from title + date: lowercase, spaces→hyphens, strip special chars."""
+    base = title.lower()
+    base = re.sub(r"[^\w\s-]", "", base)
+    base = re.sub(r"[\s_]+", "-", base).strip("-")
+    try:
+        dt   = datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+        date = dt.strftime("%Y-%m-%d")
+    except Exception:
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return f"{base}-{date}"
+
+
+def _merge_posts(existing: list[dict], new_items: list[dict]) -> list[dict]:
+    """Deduplicate by slug, merge, sort newest-first, cap at _MAX_POSTS."""
+    seen      = {p["slug"] for p in existing}
+    additions = [item for item in new_items if item["slug"] not in seen]
+    merged    = existing + additions
+    merged.sort(key=lambda p: p.get("published_at", ""), reverse=True)
+    return merged[:_MAX_POSTS]
+
+
+def download_payload(bucket_name: str) -> Optional[dict]:
+    try:
+        _, blob = _client_and_blob(bucket_name)
+        if not blob.exists():
+            log.warning("event=blog_download_missing bucket=%s", bucket_name)
+            return None
+        data    = blob.download_as_text()
+        payload = json.loads(data)
+        log.info(
+            "event=blog_download ok bucket=%s total=%d",
+            bucket_name,
+            payload.get("total", "?"),
+        )
+        return payload
+    except Exception as exc:
+        log.error("event=blog_download_failed bucket=%s error=%s", bucket_name, exc)
+        return None
+
+
+def _upload(posts: list[dict], bucket_name: str) -> bool:
+    payload = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "total":        len(posts),
+        "posts":        posts,
+    }
+    try:
+        _, blob = _client_and_blob(bucket_name)
+        blob.upload_from_string(
+            json.dumps(payload, indent=2),
+            content_type="application/json",
+        )
+        log.info("event=blog_upload ok bucket=%s total=%d", bucket_name, len(posts))
+        return True
+    except Exception as exc:
+        log.error("event=blog_upload_failed bucket=%s error=%s", bucket_name, exc)
+        return False
+
+
+def ingest_posts(new_items: list[dict], bucket_name: str) -> tuple[int, int]:
+    """Merge new posts into storage.  Returns (added_count, total_count)."""
+    existing_payload = download_payload(bucket_name)
+    existing         = existing_payload.get("posts", []) if existing_payload else []
+    seen             = {p["slug"] for p in existing}
+    added_count      = sum(1 for item in new_items if item["slug"] not in seen)
+    merged           = _merge_posts(existing, new_items)
+    _upload(merged, bucket_name)
+    return added_count, len(merged)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,6 +18,7 @@
                 <a href="/dashboard" {% if active_page == 'dashboard' %}class="nav-active"{% endif %}>Dashboard</a>
                 <a href="/signals" {% if active_page == 'signals' %}class="nav-active"{% endif %}>Signals</a>
                 <a href="/news" {% if active_page == 'news' %}class="nav-active"{% endif %}>News</a>
+                <a href="/blog" {% if active_page == 'blog' %}class="nav-active"{% endif %}>Blog</a>
                 <a href="/health">Health</a>
             </nav>
         </div>

--- a/app/templates/blog_list.html
+++ b/app/templates/blog_list.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+
+{% block title %}Blog{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>Blog</h1>
+        <p class="page-subtitle">
+            Research, analysis, and market commentary from the AlphaForgeAI team.
+        </p>
+    </div>
+    {% if total %}
+    <div class="news-header-meta">
+        <span class="news-count-pill">{{ total }} post{% if total != 1 %}s{% endif %}</span>
+        {% if generated_at %}
+        <span class="news-updated">Updated {{ generated_at | format_pub_time }}</span>
+        {% endif %}
+    </div>
+    {% endif %}
+</div>
+
+{% if posts %}
+<div class="news-feed">
+    {% for post in posts %}
+    <article class="news-card">
+
+        <div class="news-card-top">
+            <a href="/blog/{{ post.slug }}" class="news-title">{{ post.title }}</a>
+            <div class="news-meta">
+                <span class="news-source">{{ post.author or "AlphaForgeAI" }}</span>
+                <span class="news-sep">&middot;</span>
+                <time class="news-time">{{ post.published_at | format_pub_time }}</time>
+            </div>
+        </div>
+
+        {% if post.tags or post.assets %}
+        <div class="news-tags">
+            {% for tag in (post.tags or []) %}
+            <span class="news-tag news-category">{{ tag }}</span>
+            {% endfor %}
+            {% for asset in (post.assets or []) %}
+            <span class="news-tag news-asset">{{ asset }}</span>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <p class="news-summary">{{ post.summary }}</p>
+
+        <a class="news-read-more" href="/blog/{{ post.slug }}">Read more &rarr;</a>
+
+    </article>
+    {% endfor %}
+</div>
+
+{% else %}
+<div class="news-empty">
+    <h3>No posts yet</h3>
+    <p>Blog posts will appear here once the pipeline delivers its first batch.</p>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/app/templates/blog_post.html
+++ b/app/templates/blog_post.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}{{ post.title }}{% endblock %}
+
+{% block content %}
+<div style="margin-bottom:16px;">
+    <a href="/blog" class="news-read-more" style="font-size:13px;">&larr; Back to Blog</a>
+</div>
+
+<article class="news-card" style="max-width:800px;">
+
+    <div class="news-card-top">
+        <h1 class="news-title" style="font-size:1.6rem;line-height:1.3;">{{ post.title }}</h1>
+        <div class="news-meta" style="margin-top:8px;">
+            <span class="news-source">{{ post.author or "AlphaForgeAI" }}</span>
+            <span class="news-sep">&middot;</span>
+            <time class="news-time">{{ post.published_at | format_pub_time }}</time>
+        </div>
+    </div>
+
+    {% if post.tags or post.assets %}
+    <div class="news-tags" style="margin-top:12px;">
+        {% for tag in (post.tags or []) %}
+        <span class="news-tag news-category">{{ tag }}</span>
+        {% endfor %}
+        {% for asset in (post.assets or []) %}
+        <span class="news-tag news-asset">{{ asset }}</span>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <div style="margin-top:24px;line-height:1.7;color:var(--text);">
+        <pre style="white-space:pre-wrap;font-family:inherit;margin:0;">{{ post.content }}</pre>
+    </div>
+
+    {% if post.sources %}
+    <div style="margin-top:32px;padding-top:16px;border-top:1px solid var(--border);">
+        <h3 style="font-size:14px;color:var(--muted);margin-bottom:10px;text-transform:uppercase;letter-spacing:0.05em;">Sources</h3>
+        <ul style="list-style:none;padding:0;margin:0;">
+            {% for source in post.sources %}
+            <li style="margin-bottom:6px;">
+                <a href="{{ source }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   style="color:var(--accent);font-size:13px;word-break:break-all;">{{ source }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
+</article>
+
+<div style="margin-top:24px;">
+    <a href="/blog" class="news-read-more" style="font-size:13px;">&larr; Back to Blog</a>
+</div>
+
+{% endblock %}

--- a/tests/test_gcs_blog.py
+++ b/tests/test_gcs_blog.py
@@ -1,0 +1,145 @@
+"""Tests for gcs_blog deduplication and merge logic, and blog route auth."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.services.gcs_blog import _MAX_POSTS, _merge_posts, slugify
+
+
+def _post(slug: str, published_at: str) -> dict:
+    return {
+        "slug":         slug,
+        "title":        "Test Post",
+        "published_at": published_at,
+        "summary":      "Test summary.",
+        "content":      "Test content.",
+        "sources":      [],
+        "assets":       ["BTC"],
+        "tags":         ["daily-brief"],
+        "author":       "AlphaForgeAI",
+    }
+
+
+# ── Unit: _merge_posts ────────────────────────────────────────────────────────
+
+class TestMergePosts:
+    def test_new_post_added(self):
+        existing = [_post("post-a-2026-06-01", "2026-06-01T10:00:00Z")]
+        new      = [_post("post-b-2026-06-02", "2026-06-02T10:00:00Z")]
+        result   = _merge_posts(existing, new)
+        assert len(result) == 2
+
+    def test_duplicate_slug_not_added(self):
+        existing = [_post("post-a-2026-06-01", "2026-06-01T10:00:00Z")]
+        new      = [_post("post-a-2026-06-01", "2026-06-01T11:00:00Z")]
+        result   = _merge_posts(existing, new)
+        assert len(result) == 1
+
+    def test_sorted_newest_first(self):
+        existing = [_post("old-2026-06-01", "2026-06-01T08:00:00Z")]
+        new      = [_post("new-2026-06-02", "2026-06-02T12:00:00Z")]
+        result   = _merge_posts(existing, new)
+        assert result[0]["slug"] == "new-2026-06-02"
+
+    def test_capped_at_max_posts(self):
+        existing = [_post(f"post-{i}-2026-01-01", "2026-01-01T00:00:00Z") for i in range(_MAX_POSTS)]
+        new      = [_post("newest-2026-06-02", "2026-06-02T12:00:00Z")]
+        result   = _merge_posts(existing, new)
+        assert len(result) == _MAX_POSTS
+
+    def test_newest_survives_cap(self):
+        existing = [_post(f"post-{i}-2026-01-01", "2026-01-01T00:00:00Z") for i in range(_MAX_POSTS)]
+        new      = [_post("newest-2026-06-02", "2026-06-02T12:00:00Z")]
+        result   = _merge_posts(existing, new)
+        assert result[0]["slug"] == "newest-2026-06-02"
+
+    def test_empty_existing(self):
+        new    = [_post("post-a-2026-06-01", "2026-06-01T10:00:00Z")]
+        result = _merge_posts([], new)
+        assert len(result) == 1
+
+    def test_empty_new(self):
+        existing = [_post("post-a-2026-06-01", "2026-06-01T10:00:00Z")]
+        result   = _merge_posts(existing, [])
+        assert len(result) == 1
+
+    def test_both_empty(self):
+        assert _merge_posts([], []) == []
+
+    def test_mixed_dup_and_new(self):
+        existing = [_post("post-a-2026-06-01", "2026-06-01T10:00:00Z")]
+        new = [
+            _post("post-a-2026-06-01", "2026-06-01T10:00:00Z"),  # duplicate
+            _post("post-b-2026-06-02", "2026-06-02T11:00:00Z"),  # new
+        ]
+        result = _merge_posts(existing, new)
+        assert len(result) == 2
+        slugs = {p["slug"] for p in result}
+        assert "post-a-2026-06-01" in slugs
+        assert "post-b-2026-06-02" in slugs
+
+
+# ── Unit: slugify ─────────────────────────────────────────────────────────────
+
+class TestSlugify:
+    def test_basic_title(self):
+        slug = slugify("Crypto Daily Brief", "2026-06-06T00:00:00Z")
+        assert slug == "crypto-daily-brief-2026-06-06"
+
+    def test_special_chars_stripped(self):
+        slug = slugify("BTC/ETH: What's Next?", "2026-06-06T00:00:00Z")
+        assert "?" not in slug
+        assert "/" not in slug
+        assert ":" not in slug
+
+    def test_date_appended(self):
+        slug = slugify("My Post", "2026-06-15T00:00:00Z")
+        assert slug.endswith("-2026-06-15")
+
+
+# ── Integration: route auth (mocked GCS) ─────────────────────────────────────
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+_VALID_POST = {
+    "slug":         "test-post-2026-06-01",
+    "title":        "Test Post",
+    "published_at": "2026-06-01T10:00:00Z",
+    "summary":      "A test summary.",
+    "content":      "Test content body.",
+    "sources":      ["https://example.com"],
+    "assets":       ["BTC"],
+    "tags":         ["test"],
+    "author":       "AlphaForgeAI",
+}
+
+
+class TestBlogRouteAuth:
+    def test_missing_api_key_returns_401_or_503(self):
+        # No key configured → 503; wrong key → 401
+        resp = client.post(
+            "/api/blog/ingest",
+            json={"schema_version": 1, "posts": [_VALID_POST]},
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert resp.status_code in (401, 503)
+
+    def test_valid_key_accepted(self):
+        with patch("app.core.config.settings.blog_ingest_api_key", "test-secret-key"), \
+             patch("app.services.gcs_blog.ingest_posts", return_value=(1, 1)):
+            resp = client.post(
+                "/api/blog/ingest",
+                json={"schema_version": 1, "posts": [_VALID_POST]},
+                headers={"Authorization": "Bearer test-secret-key"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["accepted"] is True
+
+    def test_invalid_slug_returns_404(self):
+        with patch("app.services.gcs_blog.download_payload", return_value={"posts": [], "total": 0, "generated_at": None}):
+            resp = client.get("/blog/nonexistent-slug-2099-01-01")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- **`app/services/gcs_blog.py`** — GCS read/write service mirroring `gcs_news.py`: dedup by slug, sort desc, cap at 50 posts
- **`app/routes/blog.py`** — `GET /blog`, `GET /blog/{slug}`, `GET /api/blog`, `POST /api/blog/ingest` (Bearer auth via `BLOG_INGEST_API_KEY`)
- **`app/core/config.py`** — Added `blog_ingest_api_key` and `gcs_blog_bucket` settings
- **`app/main.py`** — Registered blog router
- **`app/templates/base.html`** — Added Blog nav link alongside News
- **`app/templates/blog_list.html`** — Card grid matching news.html style; empty state handled
- **`app/templates/blog_post.html`** — Full post view: title, author, date, tags, assets, content (pre-formatted), sources section, back link
- **`tests/test_gcs_blog.py`** — 12 tests covering merge/dedup logic, slugify, route auth, 404 on missing slug

## GCS bucket

Bucket `gs://alphaforgeai-blog` created in `us-central1`.
Service account `14641351541-compute@developer.gserviceaccount.com` granted `roles/storage.objectAdmin`.

## Cloud Run env vars set

`BLOG_INGEST_API_KEY` and `GCS_BLOG_BUCKET=alphaforgeai-blog` set on service `alphaforgeai` (revision `alphaforgeai-00015-rmg`).

**BLOG_INGEST_API_KEY:** `ZlQN...us4d` (first 4: `ZlQN`, last 4: `us4d`)

## Verification

```
curl -s https://alphaforgeai.io/api/blog
{"posts":[],"total":0,"generated_at":null}

curl -s -o /dev/null -w "%{http_code}" https://alphaforgeai.io/blog
200
```

## Deviations from spec

None. All acceptance criteria from Issue #52 are met.