### PR TITLE
fix(news): standardize sentiment to bullish/bearish/neutral only

### DIFF
--- a/n8n/alphaforgeai_news_ingest.json
+++ b/n8n/alphaforgeai_news_ingest.json
@@ -208,7 +208,7 @@
         300
       ],
       "parameters": {
-        "jsCode": "const results = [];\nfor (const item of $input.all()) {\n  try {\n    // OpenAI HTTP response is in item.json\n    const oaiResp = item.json;\n    const content = oaiResp.choices && oaiResp.choices[0]\n      ? oaiResp.choices[0].message.content\n      : (oaiResp.content || '{}');\n    const cleaned = content.replace(/^```json/gi,'').replace(/^```/gi,'').replace(/```$/gi,'').trim();\n    const analysis = JSON.parse(cleaned);\n    // Get original article from the paired item in Build OpenAI Request\n    const orig = $('Build OpenAI Request').item.json;\n    results.push({ json: {\n      title: orig.title || '',\n      url: orig.url || '',\n      source: orig.source || '',\n      published_at: orig.published_at || new Date().toISOString(),\n      relevance_score: Number(analysis.relevance_score) || 0,\n      summary: analysis.summary || '',\n      category: analysis.category || 'other',\n      assets: analysis.assets || [],\n      sentiment: analysis.sentiment || 'neutral'\n    }});\n  } catch(e) { continue; }\n}\nreturn results;\n"
+        "jsCode": "const results = [];\nfor (const item of $input.all()) {\n  try {\n    // OpenAI HTTP response is in item.json\n    const oaiResp = item.json;\n    const content = oaiResp.choices && oaiResp.choices[0]\n      ? oaiResp.choices[0].message.content\n      : (oaiResp.content || '{}');\n    const cleaned = content.replace(/^```json/gi,'').replace(/^```/gi,'').replace(/```$/gi,'').trim();\n    const analysis = JSON.parse(cleaned);\n    // Get original article from the paired item in Build OpenAI Request\n    const orig = $('Build OpenAI Request').item.json;\n    \n    // Normalize sentiment to bullish/bearish/neutral only\n    var rawSentiment = (analysis.sentiment || 'neutral').toLowerCase().trim();\n    var sentiment;\n    if (rawSentiment === 'bullish' || rawSentiment === 'positive' || rawSentiment === 'bull') {\n      sentiment = 'bullish';\n    } else if (rawSentiment === 'bearish' || rawSentiment === 'negative' || rawSentiment === 'bear') {\n      sentiment = 'bearish';\n    } else {\n      sentiment = 'neutral';\n    }\n    results.push({ json: {\n      title: orig.title || '',\n      url: orig.url || '',\n      source: orig.source || '',\n      published_at: orig.published_at || new Date().toISOString(),\n      relevance_score: Number(analysis.relevance_score) || 0,\n      summary: analysis.summary || '',\n      category: analysis.category || 'other',\n      assets: analysis.assets || [],\n      sentiment: sentiment\n    }});\n  } catch(e) { continue; }\n}\nreturn results;\n"
       }
     },
     {
@@ -352,7 +352,7 @@
       ],
       "parameters": {
         "language": "javaScript",
-        "jsCode": "const item = $input.item.json;\nconst title = item.title || '';\nconst snippet = item.contentSnippet || item.description || '';\nconst content = snippet.substring(0, 800);\nconst sysMsg = 'You are a crypto market analyst. Respond ONLY with valid JSON, no markdown. Format: {\"relevance_score\": 5, \"summary\": \"text\", \"category\": \"market\", \"assets\": [\"BTC\"], \"sentiment\": \"neutral\"}';\nconst body = JSON.stringify({\n  model: 'gpt-4o-mini', temperature: 0.1, max_tokens: 400,\n  messages: [{role:'system',content:sysMsg},{role:'user',content:'Title: '+title+' '+content}]\n});\nreturn {json: {...item, openai_body: body}};\n"
+        "jsCode": "const item = $input.item.json;\nconst title = item.title || '';\nconst snippet = item.contentSnippet || item.description || '';\nconst content = snippet.substring(0, 800);\nconst sysMsg = 'You are a crypto market analyst. Respond ONLY with valid JSON, no markdown. Format: {\"relevance_score\": 5, \"summary\": \"text\", \"category\": \"market\", \"assets\": [\"BTC\"], \"sentiment\": \"bullish or bearish or neutral (ONLY these three values)\"}';\nconst body = JSON.stringify({\n  model: 'gpt-4o-mini', temperature: 0.1, max_tokens: 400,\n  messages: [{role:'system',content:sysMsg},{role:'user',content:'Title: '+title+' '+content}]\n});\nreturn {json: {...item, openai_body: body}};\n"
       }
     }
   ],
@@ -632,8 +632,8 @@
     "availableInMCP": false
   },
   "meta": {
-    "description": "AlphaForgeAI crypto news ingest \u2014 4x/day, 8 RSS sources, OpenAI scoring",
-    "version": "1.3.0",
-    "updated": "2026-06-05"
+    "description": "AlphaForgeAI crypto news ingest \u2014 sentiment: bullish/bearish/neutral only",
+    "version": "1.4.0",
+    "updated": "2026-06-06"
   }
 }


### PR DESCRIPTION
## Problem
News articles were using `negative` and `positive` as sentiment values instead of the correct `bearish` and `bullish`.

## Root cause
The GPT system prompt only showed `"sentiment": "neutral"` as the example, so GPT invented its own values.

## Fixes

### n8n — Build OpenAI Request node
Prompt now explicitly states: `"sentiment": "bullish or bearish or neutral (ONLY these three values)"`

### n8n — Parse OpenAI Response node  
Added normalization layer after parsing:
```
negative / bear  → bearish
positive / bull  → bullish
anything else    → neutral
```

### GCS backfill
3 existing articles fixed in-place:
- Zcash Bug Crisis: `negative` → `bearish`
- Government Stablecoin Tax Evasion: `negative` → `bearish`
- ZCash Exploit Morning Minute: `negative` → `bearish`

## Verified
```
Sentiment values in use: {'neutral', 'bearish'}
```
All 13 live articles now use only valid values. `bullish` will appear once a positive story comes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)