### PR TITLE
feat(signals): top 10 by confidence with ?limit=all bypass (closes #40)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -119,6 +119,13 @@ class Settings:
         ).strip().lower() in ("1", "true", "yes")
     )
 
+    # ── Signal display limit ─────────────────────────────────────────────────
+    # Max signals shown on /signals, ranked by confidence desc before limiting.
+    # 0 = show all. Override with SIGNAL_DISPLAY_LIMIT env var or ?limit=all.
+    signal_display_limit: int = field(
+        default_factory=lambda: _int_env("SIGNAL_DISPLAY_LIMIT", 10)
+    )
+
     # ── Confluence engine ────────────────────────────────────────────────────
     # SIGNAL_CONFLUENCE=true  → run the multi-TF confluence engine after load
     # SIGNAL_CONFLUENCE_FILTER=true → only return confluent signals (full/partial)

--- a/app/routes/signals.py
+++ b/app/routes/signals.py
@@ -27,15 +27,29 @@ templates.env.filters["importance_percent"] = normalize_percent
 
 @router.get("/signals", response_class=HTMLResponse)
 async def signal_feed(request: Request):
-    snapshot = get_signals()
+    snapshot  = get_signals()
     staleness = evaluate_signal_staleness(snapshot.generated_at)
-    signals = []
+    signals   = []
     if not (staleness.is_stale and staleness.action == "filter"):
         signals = snapshot.signals
+
+    # Sort by confidence desc (highest-conviction signals first)
+    signals = sorted(signals, key=lambda s: getattr(s, "confidence", 0) or 0, reverse=True)
+
+    # Apply display limit — ?limit=all bypasses the cap
+    limit_param   = request.query_params.get("limit", "").strip().lower()
+    show_all      = limit_param == "all" or settings.signal_display_limit == 0
+    total_signals = len(signals)
+    if not show_all and settings.signal_display_limit > 0:
+        signals = signals[:settings.signal_display_limit]
+    limit_active  = not show_all and total_signals > len(signals)
+
     log.info(
-        "event=signal_feed_render signal_count=%d source=%s status=%s "
+        "event=signal_feed_render signal_count=%d total=%d limit=%d source=%s status=%s "
         "used_mock_fallback=%s generated_at=%s model_version=%s",
         len(signals),
+        total_signals,
+        settings.signal_display_limit,
         snapshot.source,
         snapshot.status,
         snapshot.used_mock_fallback,
@@ -65,6 +79,9 @@ async def signal_feed(request: Request):
         # signal data
         "signals":            signals,
         "total":              len(signals),
+        "total_available":    total_signals,
+        "limit_active":       limit_active,
+        "display_limit":      settings.signal_display_limit,
         "long_count":         sum(1 for s in signals if s.direction == "LONG"),
         "short_count":        sum(1 for s in signals if s.direction == "SHORT"),
         "flat_count":         sum(1 for s in signals if s.direction == "FLAT"),

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -327,6 +327,11 @@ nav a.nav-active { color: var(--text); font-weight: 600; }
     color: var(--danger);
     background: var(--tint-short);
 }
+.snapshot-notice-info {
+    border-color: var(--accent);
+    color: var(--text);
+    background: var(--surface3);
+}
 
 /* ── Signal feed ─────────────────────────────────────────────── */
 .signal-feed { display: flex; flex-direction: column; gap: 14px; }

--- a/app/templates/signals.html
+++ b/app/templates/signals.html
@@ -17,6 +17,14 @@
     </div>
 </div>
 
+{# ── Limit banner ────────────────────────────────────────────────────────── #}
+{% if limit_active %}
+<div class="snapshot-notice snapshot-notice-info" style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;">
+    <span>Showing top <strong>{{ display_limit }}</strong> of <strong>{{ total_available }}</strong> signals by confidence.</span>
+    <a href="/signals?limit=all" class="news-read-more" style="font-size:13px;white-space:nowrap;">Show all {{ total_available }} &rarr;</a>
+</div>
+{% endif %}
+
 {# ── Source meta bar ──────────────────────────────────────────────────────── #}
 <div class="source-meta">
     <span class="source-status-dot


### PR DESCRIPTION
## Summary

Implements Issue #40 — filter and rank signal feed to show top 10 by confidence.

## Changes

### `app/core/config.py`
- `signal_display_limit` setting (env: `SIGNAL_DISPLAY_LIMIT`, default: `10`)
- `0` = show all signals

### `app/routes/signals.py`
1. Sort signals by confidence descending before any limit is applied
2. Apply `signal_display_limit` after staleness filter
3. `?limit=all` query param bypasses the cap entirely
4. Passes `limit_active`, `total_available`, `display_limit` to template

### `app/templates/signals.html`
- Banner when limit is active: `Showing top 10 of N signals by confidence`
- `Show all N →` link that appends `?limit=all`

### `app/static/css/styles.css`
- `snapshot-notice-info` variant (accent border, readable text)

## Acceptance criteria
- [x] Signals ranked by confidence desc before limit
- [x] Limit applied after staleness filter
- [x] UI shows 'Showing top 10 of N' when limit active
- [x] `?limit=all` bypasses cap
- [x] `SIGNAL_DISPLAY_LIMIT=0` env var shows all (no banner)

## Deploy note
No new env vars required — defaults to 10. To change: set `SIGNAL_DISPLAY_LIMIT` in Cloud Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)