### PR TITLE
feat: VPS2 n8n container uptime monitor (Issue #51 gap #1)

### DIFF
--- a/n8n/alphaforgeai_monitor.json
+++ b/n8n/alphaforgeai_monitor.json
@@ -1,0 +1,173 @@
+{
+  "name": "AlphaForgeAI Monitor",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 15
+            }
+          ]
+        }
+      },
+      "id": "a1b2c3d4-0001-0001-0001-000000000001",
+      "name": "Every 15 Minutes",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "url": "https://alphaforgeai.io/api/news",
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "id": "a1b2c3d4-0002-0002-0002-000000000002",
+      "name": "Check News Feed",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, 300],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check news feed freshness and build alert status\n// All ES5/ASCII -- no template literals, no Unicode special chars\nvar item = $input.item.json;\nvar now = new Date();\nvar alertNeeded = false;\nvar alertReason = '';\nvar alertSeverity = 'warn'; // 'warn' or 'crit'\n\n// Check for HTTP error (continueOnFail passes error as item.error)\nif (item.error || $input.item.pairedItem === undefined) {\n  alertNeeded = true;\n  alertReason = 'AlphaForgeAI /api/news endpoint is unreachable or returned an error.';\n  alertSeverity = 'crit';\n} else {\n  var generatedAt = item.generated_at || '';\n  if (!generatedAt) {\n    alertNeeded = true;\n    alertReason = 'News feed response missing generated_at field. Feed may be empty or broken.';\n    alertSeverity = 'warn';\n  } else {\n    // Parse timestamp\n    var ts = new Date(generatedAt.replace('Z', '+00:00'));\n    var ageMinutes = Math.floor((now - ts) / 60000);\n    // Alert if feed is older than 8 hours (480 minutes)\n    // News workflow runs 4x/day so max gap is ~6h; 8h allows buffer\n    if (ageMinutes > 480) {\n      alertNeeded = true;\n      alertReason = 'News feed has not been updated in ' + ageMinutes + ' minutes (>' + Math.floor(ageMinutes/60) + 'h). Last update: ' + generatedAt;\n      alertSeverity = 'warn';\n    }\n  }\n}\n\nreturn [{\n  json: {\n    alertNeeded: alertNeeded,\n    alertReason: alertReason,\n    alertSeverity: alertSeverity,\n    checkedAt: now.toISOString(),\n    generatedAt: (item && item.generated_at) ? item.generated_at : 'unknown',\n    totalArticles: (item && item.total) ? item.total : 0\n  }\n}];"
+      },
+      "id": "a1b2c3d4-0003-0003-0003-000000000003",
+      "name": "Evaluate Freshness",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-001",
+              "leftValue": "={{ $json.alertNeeded }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "a1b2c3d4-0004-0004-0004-000000000004",
+      "name": "Alert Needed?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build Discord embed payload\nvar d = $input.item.json;\nvar isCrit = (d.alertSeverity === 'crit');\nvar color = isCrit ? 15158332 : 16776960; // red or yellow\nvar emoji = isCrit ? ':red_circle:' : ':warning:';\nvar title = emoji + ' AlphaForgeAI News Alert';\nvar desc = d.alertReason + '\\n\\nChecked at: ' + d.checkedAt;\n\nreturn [{\n  json: {\n    payload: JSON.stringify({\n      embeds: [{\n        title: title,\n        description: desc,\n        color: color,\n        timestamp: d.checkedAt\n      }]\n    })\n  }\n}];"
+      },
+      "id": "a1b2c3d4-0005-0005-0005-000000000005",
+      "name": "Build Discord Payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discordapp.com/api/webhooks/1321695633959284787/3bXfwNb2kMLtDwdJnQc5Ydx_3CPbmWPbnDC55DW6WHHv_QN3kMZL8CFR4vlSz5lHGvFF",
+        "contentType": "raw",
+        "rawContentType": "application/json",
+        "body": "={{ $json.payload }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "a1b2c3d4-0006-0006-0006-000000000006",
+      "name": "Send Discord Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1340, 200],
+      "continueOnFail": true
+    }
+  ],
+  "connections": {
+    "Every 15 Minutes": {
+      "main": [
+        [
+          {
+            "node": "Check News Feed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check News Feed": {
+      "main": [
+        [
+          {
+            "node": "Evaluate Freshness",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Evaluate Freshness": {
+      "main": [
+        [
+          {
+            "node": "Alert Needed?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Alert Needed?": {
+      "main": [
+        [
+          {
+            "node": "Build Discord Payload",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        []
+      ]
+    },
+    "Build Discord Payload": {
+      "main": [
+        [
+          {
+            "node": "Send Discord Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "callerPolicy": "workflowsFromSameOwner",
+    "errorWorkflow": ""
+  },
+  "staticData": null,
+  "tags": ["alphaforgeai", "monitor"],
+  "triggerCount": 0,
+  "updatedAt": "2026-06-07T00:00:00.000Z",
+  "versionId": "monitor-v1.0.0"
+}

--- a/scripts/vps2_n8n_monitor.sh
+++ b/scripts/vps2_n8n_monitor.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# =============================================================================
+# VPS2 n8n Container Health Monitor
+# =============================================================================
+# Checks that stack-n8n-1 is running and HTTP-responsive.
+# If down: attempts restart via docker compose, sends Discord alert either way.
+#
+# Cron: */5 * * * * /opt/n8n-monitor/vps2_n8n_monitor.sh >> /var/log/n8n-monitor.log 2>&1
+# =============================================================================
+
+CONTAINER_NAME="stack-n8n-1"
+COMPOSE_DIR="/opt/stack"
+N8N_HEALTH_URL="http://172.18.0.10:5678/healthz"
+DISCORD_WEBHOOK="https://discordapp.com/api/webhooks/1321695633959284787/3bXfwNb2kMLtDwdJnQc5Ydx_3CPbmWPbnDC55DW6WHHv_QN3kMZL8CFR4vlSz5lHGvFF"
+LOG_PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')] [n8n-monitor]"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() {
+    echo "$LOG_PREFIX $1"
+}
+
+discord_alert() {
+    local title="$1"
+    local description="$2"
+    local color="$3"   # 15158332 = red, 16776960 = yellow, 3066993 = green
+    curl -s -o /dev/null -X POST "$DISCORD_WEBHOOK" \
+        -H "Content-Type: application/json" \
+        -d "{\"embeds\":[{\"title\":\"$title\",\"description\":\"$description\",\"color\":$color,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)\"}]}"
+}
+
+container_running() {
+    local status
+    status=$(docker inspect --format='{{.State.Status}}' "$CONTAINER_NAME" 2>/dev/null)
+    [ "$status" = "running" ]
+}
+
+http_healthy() {
+    local code
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$N8N_HEALTH_URL" 2>/dev/null)
+    [[ "$code" =~ ^(200|301|302|401)$ ]]
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+# 1. Check Docker container state
+if ! container_running; then
+    log "WARN: Container $CONTAINER_NAME is NOT running. Attempting restart..."
+    discord_alert \
+        ":warning: n8n Container Down" \
+        "Container \`$CONTAINER_NAME\` was found stopped on VPS2. Attempting automatic restart via docker compose." \
+        "16776960"
+
+    cd "$COMPOSE_DIR" && docker compose up -d n8n
+    sleep 15
+
+    if container_running; then
+        log "OK: Container restarted successfully."
+        discord_alert \
+            ":white_check_mark: n8n Restarted" \
+            "Container \`$CONTAINER_NAME\` was restarted and is now running. Monitor continues." \
+            "3066993"
+    else
+        log "ERROR: Container restart FAILED. Manual intervention required."
+        discord_alert \
+            ":red_circle: n8n Restart FAILED" \
+            "CRITICAL: \`$CONTAINER_NAME\` could not be restarted automatically on VPS2. **Manual intervention required immediately.**" \
+            "15158332"
+    fi
+    exit 0
+fi
+
+# 2. Container is running — verify HTTP health
+if ! http_healthy; then
+    log "WARN: Container running but HTTP health check failed on $N8N_HEALTH_URL"
+    discord_alert \
+        ":warning: n8n Unresponsive" \
+        "Container \`$CONTAINER_NAME\` is running but not responding to HTTP health checks at \`$N8N_HEALTH_URL\`. Workflows may be stalled." \
+        "16776960"
+    exit 1
+fi
+
+# 3. All good
+log "OK: $CONTAINER_NAME is running and HTTP-healthy."
+exit 0


### PR DESCRIPTION
## Summary

Closes Issue #51 gap #1: n8n container was found stopped on 2026-06-04 with no alerting or auto-recovery.

**Two-layer monitoring approach:**

### Layer 1 — System-level cron (works even when n8n is down)
- `scripts/vps2_n8n_monitor.sh` deployed to `/opt/n8n-monitor/` on VPS2
- Cron job: every 5 minutes (`*/5 * * * *`)
- Checks `stack-n8n-1` Docker container state
- If stopped → runs `docker compose up -d n8n` from `/opt/stack/`
- Sends Discord alert on: container down, successful restart, restart failure
- Uses monitoring webhook (`1321695633959284787`)
- ✅ Tested live: script confirmed healthy on current n8n state

### Layer 2 — n8n workflow (detects silent feed failures)
- `n8n/alphaforgeai_monitor.json` — imported and **activated** (ID: `RQj15rCrt0xrXsGb`)
- Runs every 15 minutes
- GETs `https://alphaforgeai.io/api/news` and checks `generated_at` age
- Alerts Discord if feed is >8 hours stale or endpoint unreachable
- Uses same monitoring Discord channel

## Test plan
- [x] Shell script ran successfully on VPS2 — returned OK (container healthy)
- [x] Cron job installed: `*/5 * * * *` on VPS2 root crontab
- [x] n8n workflow imported via API and activated
- [ ] Verify Discord alert fires on next manual trigger in n8n UI
- [ ] Monitor `/var/log/n8n-monitor.log` on VPS2 after first few cron runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)