### PR TITLE
feat: Alpha Alerts Phase 1 — signals JSON API + n8n auto-post workflow

### DIFF
--- a/app/routes/signals.py
+++ b/app/routes/signals.py
@@ -1,7 +1,7 @@
 import logging
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from pathlib import Path
 
@@ -23,6 +23,34 @@ templates.env.filters["confidence_percent"] = confidence_percent
 templates.env.filters["confidence_label"] = confidence_label
 templates.env.filters["confidence_css_class"] = confidence_css_class
 templates.env.filters["importance_percent"] = normalize_percent
+
+
+@router.get("/api/signals/snapshot")
+async def signals_snapshot():
+    """Public JSON endpoint — top signals by confidence for n8n and external consumers."""
+    snapshot  = get_signals()
+    staleness = evaluate_signal_staleness(snapshot.generated_at)
+    signals   = []
+    if not (staleness.is_stale and staleness.action == "filter"):
+        signals = sorted(snapshot.signals, key=lambda s: getattr(s, "confidence", 0) or 0, reverse=True)
+
+    return JSONResponse({
+        "generated_at": snapshot.generated_at,
+        "signal_count":  len(signals),
+        "is_stale":      staleness.is_stale,
+        "signals": [
+            {
+                "symbol":     s.symbol,
+                "direction":  s.direction,
+                "confidence": round(s.confidence, 4),
+                "regime":     s.regime,
+                "timeframe":  s.timeframe,
+                "thesis":     s.thesis,
+                "confluence": s.confluence,
+            }
+            for s in signals
+        ],
+    })
 
 
 @router.get("/signals", response_class=HTMLResponse)

--- a/app/services/gcs_news.py
+++ b/app/services/gcs_news.py
@@ -42,13 +42,13 @@ def _split_articles(articles: list[dict]) -> tuple[list[dict], list[dict]]:
     return fresh, aged
 
 
-def _merge_articles(existing: list[dict], new_items: list[dict]) -> list[dict]:
-    """Deduplicate by URL, merge, sort newest-first."""
+def _merge_articles(existing: list[dict], new_items: list[dict], max_items: int | None = _MAX_ARTICLES) -> list[dict]:
+    """Deduplicate by URL, merge, sort newest-first. Capped at max_items (None = unlimited)."""
     seen = {a["url"] for a in existing}
     additions = [item for item in new_items if item["url"] not in seen]
     merged = existing + additions
     merged.sort(key=lambda a: a.get("published_at", ""), reverse=True)
-    return merged
+    return merged if max_items is None else merged[:max_items]
 
 
 def _archive_articles(aged: list[dict], bucket_name: str) -> None:
@@ -61,7 +61,7 @@ def _archive_articles(aged: list[dict], bucket_name: str) -> None:
             existing = json.loads(blob.download_as_text()).get("articles", [])
         else:
             existing = []
-        merged = _merge_articles(existing, aged)
+        merged = _merge_articles(existing, aged, max_items=None)
         merged.sort(key=lambda a: a.get("published_at", ""), reverse=True)
         payload = {
             "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/n8n/alphaforgeai_alpha_alerts.json
+++ b/n8n/alphaforgeai_alpha_alerts.json
@@ -1,1 +1,109 @@
-[{"updatedAt":"2026-06-22T12:22:37.480Z","createdAt":"2026-06-13T03:02:45.938Z","id":"v8nE9uHXBehWFV5q","name":"AlphaForgeAI — Alpha Alerts","description":null,"active":true,"isArchived":false,"nodes":[{"parameters":{"rule":{"interval":[{"field":"hours","hoursInterval":4}]}},"id":"schedule-trigger","name":"Every 4 Hours","type":"n8n-nodes-base.scheduleTrigger","typeVersion":1.2,"position":[240,300]},{"parameters":{"url":"https://alphaforgeai.io/api/signals/snapshot","options":{}},"id":"fetch-signals","name":"Fetch Signals","type":"n8n-nodes-base.httpRequest","typeVersion":4.2,"position":[460,300]},{"parameters":{"jsCode":"const data = $input.first().json;\n\nif (data.is_stale) {\n  return [{ json: { skip: true, reason: 'signals stale' } }];\n}\n\nconst signals = data.signals || [];\n\n// Top 3 highest confidence non-FLAT signals\nconst top = signals\n  .filter(s => s.direction !== 'FLAT' && s.confidence >= 0.65)\n  .slice(0, 3);\n\nif (top.length === 0) {\n  return [{ json: { skip: true, reason: 'no high-confidence signals' } }];\n}\n\nconst dirEmoji = { LONG: '🟢', SHORT: '🔴' };\nconst confLabel = c => c >= 0.85 ? 'Very High' : c >= 0.75 ? 'High' : c >= 0.65 ? 'Moderate' : 'Low';\n\nconst lines = top.map(s =>\n  `${dirEmoji[s.direction]} ${s.symbol} — ${s.direction} | Conf: ${confLabel(s.confidence)} (${Math.round(s.confidence * 100)}%) | ${s.regime}`\n);\n\nconst generatedAt = data.generated_at\n  ? new Date(data.generated_at).toUTCString().replace(':00 GMT', ' UTC')\n  : 'now';\n\nconst tweet = [\n  `⚡ Alpha Alerts — ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`,\n  '',\n  ...lines,\n  '',\n  `Signals updated: ${generatedAt}`,\n  'Full dashboard 👉 https://alphaforgeai.io/signals',\n  '',\n  '#Crypto #Bitcoin #Ethereum #AlphaForgeAI #AlphaAlerts #CryptoSignals #Trading'\n].join('\\n');\n\nreturn [{ json: { tweet, signal_count: top.length, skip: false } }];"},"id":"build-alert","name":"Build Alpha Alert","type":"n8n-nodes-base.code","typeVersion":2,"position":[680,300]},{"parameters":{"conditions":{"options":{"caseSensitive":true,"leftValue":"","typeValidation":"strict"},"conditions":[{"id":"skip-check","leftValue":"={{ $json.skip }}","rightValue":false,"operator":{"type":"boolean","operation":"equals"}}],"combinator":"and"},"options":{}},"id":"check-skip","name":"Has Alerts?","type":"n8n-nodes-base.if","typeVersion":2.2,"position":[900,300]},{"parameters":{"text":"={{ $json.tweet }}","additionalFields":{}},"id":"post-to-x","name":"Post to X","type":"n8n-nodes-base.twitter","typeVersion":1,"position":[1120,200],"credentials":{"twitterOAuth1Api":{"id":"WPpWGXWXaAS8H8ng","name":"X (Twitter) OAuth1"}}},{"parameters":{"level":"info","message":"Alpha Alert skipped: {{ $json.reason }}"},"id":"log-skip","name":"Log Skip","type":"n8n-nodes-base.noOp","typeVersion":1,"position":[1120,420]}],"connections":{"Every 4 Hours":{"main":[[{"node":"Fetch Signals","type":"main","index":0}]]},"Fetch Signals":{"main":[[{"node":"Build Alpha Alert","type":"main","index":0}]]},"Build Alpha Alert":{"main":[[{"node":"Has Alerts?","type":"main","index":0}]]},"Has Alerts?":{"main":[[{"node":"Post to X","type":"main","index":0}],[{"node":"Log Skip","type":"main","index":0}]]}},"settings":{"executionOrder":"v1","saveManualExecutions":true,"callerPolicy":"workflowsFromSameOwner","errorWorkflow":"","availableInMCP":false},"staticData":{"node:Every 4 Hours":{"recurrenceRules":[8]}},"meta":null,"pinData":null,"versionId":"483cf94c-bf74-43fd-be74-d13ceae3b15e","activeVersionId":"483cf94c-bf74-43fd-be74-d13ceae3b15e","versionCounter":50,"triggerCount":1,"tags":[],"shared":[{"updatedAt":"2026-06-13T03:02:45.938Z","createdAt":"2026-06-13T03:02:45.938Z","role":"workflow:owner","workflowId":"v8nE9uHXBehWFV5q","projectId":"Hpq6RFprZLmqJoZi","project":{"updatedAt":"2025-10-24T01:13:40.946Z","createdAt":"2025-10-24T00:51:32.970Z","id":"Hpq6RFprZLmqJoZi","name":"Josh Grace <bgkegger34@gmail.com>","type":"personal","icon":null,"description":null,"creatorId":"d19f703f-0161-47c5-8fda-00ff16f8c9d5"}}]}]
+{
+  "name": "AlphaForgeAI — Alpha Alerts",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [{ "field": "hours", "hoursInterval": 4 }]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Every 4 Hours",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "url": "https://alphaforgeai.io/api/signals/snapshot",
+        "options": {}
+      },
+      "id": "fetch-signals",
+      "name": "Fetch Signals",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "const data = $input.first().json;\n\nif (data.is_stale) {\n  return [{ json: { skip: true, reason: 'signals stale' } }];\n}\n\nconst signals = data.signals || [];\n\n// Top 3 highest confidence non-FLAT signals\nconst top = signals\n  .filter(s => s.direction !== 'FLAT' && s.confidence >= 0.65)\n  .slice(0, 3);\n\nif (top.length === 0) {\n  return [{ json: { skip: true, reason: 'no high-confidence signals' } }];\n}\n\nconst dirEmoji = { LONG: '🟢', SHORT: '🔴' };\nconst confLabel = c => c >= 0.85 ? 'Very High' : c >= 0.75 ? 'High' : c >= 0.65 ? 'Moderate' : 'Low';\n\nconst lines = top.map(s =>\n  `${dirEmoji[s.direction]} ${s.symbol} — ${s.direction} | Conf: ${confLabel(s.confidence)} (${Math.round(s.confidence * 100)}%) | ${s.regime}`\n);\n\nconst generatedAt = data.generated_at\n  ? new Date(data.generated_at).toUTCString().replace(':00 GMT', ' UTC')\n  : 'now';\n\nconst tweet = [\n  `⚡ Alpha Alerts — ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`,\n  '',\n  ...lines,\n  '',\n  `Signals updated: ${generatedAt}`,\n  'Full dashboard 👉 https://alphaforgeai.io/signals',\n  '',\n  '#Crypto #Bitcoin #Ethereum #AlphaForgeAI #AlphaAlerts #CryptoSignals #Trading'\n].join('\\n');\n\nreturn [{ json: { tweet, signal_count: top.length, skip: false } }];"
+      },
+      "id": "build-alert",
+      "name": "Build Alpha Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "skip-check",
+              "leftValue": "={{ $json.skip }}",
+              "rightValue": false,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-skip",
+      "name": "Has Alerts?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "text": "={{ $json.tweet }}",
+        "additionalFields": {}
+      },
+      "id": "post-to-x",
+      "name": "Post to X",
+      "type": "n8n-nodes-base.twitter",
+      "typeVersion": 2,
+      "position": [1120, 200],
+      "continueOnFail": true,
+      "credentials": {
+        "twitterOAuth1Api": {
+          "id": "WPpWGXWXaAS8H8ng",
+          "name": "X (Twitter) OAuth1"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "level": "info",
+        "message": "Alpha Alert skipped: {{ $json.reason }}"
+      },
+      "id": "log-skip",
+      "name": "Log Skip",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [1120, 420]
+    }
+  ],
+  "connections": {
+    "Every 4 Hours": { "main": [[{ "node": "Fetch Signals", "type": "main", "index": 0 }]] },
+    "Fetch Signals":  { "main": [[{ "node": "Build Alpha Alert", "type": "main", "index": 0 }]] },
+    "Build Alpha Alert": { "main": [[{ "node": "Has Alerts?", "type": "main", "index": 0 }]] },
+    "Has Alerts?": {
+      "main": [
+        [{ "node": "Post to X", "type": "main", "index": 0 }],
+        [{ "node": "Log Skip", "type": "main", "index": 0 }]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "callerPolicy": "workflowsFromSameOwner",
+    "errorWorkflow": ""
+  },
+  "staticData": null,
+  "meta": { "templateCredsSetupCompleted": true },
+  "pinData": {}
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/signals/snapshot` — public JSON endpoint returning all signals sorted by confidence, enabling n8n and external consumers to read signal data without scraping the HTML page
- Adds `n8n/alphaforgeai_alpha_alerts.json` — workflow that fires every 4 hours, fetches top 3 high-confidence (≥65%) LONG/SHORT signals, formats an Alpha Alert tweet, and posts to X via the wired OAuth1 credential
- Workflow skips gracefully when signals are stale or no qualifying alerts exist

## Deployed
- n8n workflow ID: `v8nE9uHXBehWFV5q` — active on VPS2
- Cloud Run redeploy needed to expose `/api/signals/snapshot`

## Test plan
- [ ] Verify `/api/signals/snapshot` returns JSON after Cloud Run redeploy
- [ ] Manually trigger n8n workflow and confirm X post
- [ ] Confirm workflow skips cleanly when confidence threshold not met

Closes part of #76

🤖 Generated with [Claude Code](https://claude.ai/claude-code)